### PR TITLE
Add support for flat transaction fetch endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - support for text map values (added in SDK 0.11.32)
 - support for CreateAndExercise command (added in SDK 0.12.9)
+- support for GetFlatTransactionById and GetFlatTransactionByEventId (added in SDK 0.12.14)
+
+### Fixed
+- add validation to GetTransactionById endpoint
 
 ## [0.5.0]
 ### Changed

--- a/grpc-codegen.sh
+++ b/grpc-codegen.sh
@@ -7,7 +7,7 @@ set -euxo pipefail
 cd "$(dirname "${0}")"
 
 GRPC_VERSION=1.18.0
-SDK_VERSION=100.12.12
+SDK_VERSION=100.12.14
 
 PROTO_PATH="./proto"
 OUT_PATH="./src/generated"

--- a/grpc-codegen.sh
+++ b/grpc-codegen.sh
@@ -23,7 +23,6 @@ if [ ! -d "$PROTO_PATH" ]; then
       cd "$PROTO_PATH"
       curl -s https://digitalassetsdk.bintray.com/DigitalAssetSDK/com/digitalasset/ledger-api-protos/"$SDK_VERSION"/ledger-api-protos-"$SDK_VERSION".tar.gz | tar xz --strip-components 2
       curl -s https://digitalassetsdk.bintray.com/DigitalAssetSDK/com/digitalasset/daml-lf-archive-protos/"$SDK_VERSION"/daml-lf-archive-protos-"$SDK_VERSION".tar.gz | tar xz --strip-components 3
-      mkdir -p da && mv com/digitalasset/daml_lf/* da && rm -rf com/digitalasset/daml_lf
       mkdir -p google/rpc
       curl -s https://raw.githubusercontent.com/grpc/grpc/v"$GRPC_VERSION"/src/proto/grpc/status/status.proto > google/rpc/status.proto
     )

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "package.json"
   ],
   "scripts": {
-    "ci-pipeline": "npm ci && ./check-copy.sh && npm run pretest && npm run test-with-fixed-seed",
+    "ci-pipeline": "npm ci && ./check-copy.sh && rm -rf proto src/generated && npm run pretest && npm run test-with-fixed-seed",
     "release-docs": "rm -rf docs && typedoc --tsconfig tsconfig-docs.json --out ./docs/$(git describe --tags) src",
     "prepack": "./grpc-codegen.sh && tsc --build tsconfig-dist.json && cp -r src/generated lib",
     "pretest": "./grpc-codegen.sh && tsc --build tsconfig-dist.json && tsc --build tsconfig-test.json",

--- a/src/client/TransactionClient.ts
+++ b/src/client/TransactionClient.ts
@@ -24,6 +24,9 @@ import {GetTransactionsRequestCodec} from "../codec/GetTransactionsRequestCodec"
 import {GetTransactionsResponseCodec} from "../codec/GetTransactionsResponseCodec";
 import {GetTransactionTreesResponse} from "../model/GetTransactionTreesResponse";
 import {GetTransactionTreesResponseCodec} from "../codec/GetTransactionTreesResponseCodec";
+import {GetFlatTransactionResponse} from "../model/GetFlatTransactionResponse";
+import {GetFlatTransactionResponseCodec} from "../codec/GetFlatTransactionResponseCodec";
+import {GetTransactionByIdRequestValidation} from "../validation/GetTransactionByIdRequestValidation";
 
 /**
  * Allows clients to read transactions from the ledger.
@@ -57,8 +60,6 @@ export class TransactionClient {
     /**
      * Lookup a transaction by the ID of an event that appears within it.
      *
-     * This call is a future extension point and is currently not supported.
-     *
      * Returns NOT_FOUND if no such transaction exists.
      */
     getTransactionByEventId(requestObject: GetTransactionByEventIdRequest, callback: Callback<GetTransactionResponse>): ClientCancellableCall {
@@ -76,18 +77,60 @@ export class TransactionClient {
     }
 
     /**
-     * Lookup a transaction by its ID.
+     * Lookup a transaction by the ID of an event that appears within it.
      *
-     * This call is a future extension point and is currently not supported.
+     * Returns ``NOT_FOUND`` if no such transaction exists.
+     */
+    getFlatTransactionByEventId(requestObject: GetTransactionByEventIdRequest, callback: Callback<GetFlatTransactionResponse>): ClientCancellableCall {
+        const tree = GetTransactionByEventIdRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = GetTransactionByEventIdRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.getFlatTransactionByEventId(request, (error, response) => {
+                forward(callback, error, response, GetFlatTransactionResponseCodec.deserialize);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+    }
+
+    /**
+     * Lookup a transaction by its ID.
      *
      * Returns NOT_FOUND if no such transaction exists.
      */
     getTransactionById(requestObject: GetTransactionByIdRequest, callback: Callback<GetTransactionResponse>): ClientCancellableCall {
-        const request = GetTransactionByIdRequestCodec.serialize(requestObject);
-        request.setLedgerId(this.ledgerId);
-        return ClientCancellableCall.accept(this.client.getTransactionById(request, (error, response) => {
-            forward(callback, error, response, GetTransactionResponseCodec.deserialize);
-        }));
+        const tree = GetTransactionByIdRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = GetTransactionByIdRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.getTransactionById(request, (error, response) => {
+                forward(callback, error, response, GetTransactionResponseCodec.deserialize);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+    }
+
+    /**
+     * Lookup a transaction by the ID of an event that appears within it.
+     *
+     * Returns ``NOT_FOUND`` if no such transaction exists.
+     */
+    getFlatTransactionById(requestObject: GetTransactionByIdRequest, callback: Callback<GetFlatTransactionResponse>): ClientCancellableCall {
+        const tree = GetTransactionByIdRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = GetTransactionByIdRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.getFlatTransactionById(request, (error, response) => {
+                forward(callback, error, response, GetFlatTransactionResponseCodec.deserialize);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
     }
 
     /**

--- a/src/codec/GetFlatTransactionResponseCodec.ts
+++ b/src/codec/GetFlatTransactionResponseCodec.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {Codec} from "./Codec";
+import {GetFlatTransactionResponse} from "../model/GetFlatTransactionResponse";
+import {TransactionCodec} from "./TransactionCodec";
+import {GetFlatTransactionResponse as PbGetFlatTransactionResponse} from "../generated/com/digitalasset/ledger/api/v1/transaction_service_pb";
+
+export const GetFlatTransactionResponseCodec: Codec<PbGetFlatTransactionResponse, GetFlatTransactionResponse> = {
+    deserialize(message: PbGetFlatTransactionResponse): GetFlatTransactionResponse {
+        return {
+            transaction: TransactionCodec.deserialize(message.getTransaction()!)
+        };
+    },
+    serialize(object: GetFlatTransactionResponse): PbGetFlatTransactionResponse {
+        const message = new PbGetFlatTransactionResponse();
+        message.setTransaction(TransactionCodec.serialize(object.transaction));
+        return message;
+    }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import {GetTimeResponse} from './model/GetTimeResponse';
 import {GetTransactionByEventIdRequest} from './model/GetTransactionByEventIdRequest';
 import {GetTransactionByIdRequest} from './model/GetTransactionByIdRequest';
 import {GetTransactionResponse} from './model/GetTransactionResponse';
+import {GetFlatTransactionResponse} from './model/GetFlatTransactionResponse';
 import {GetTransactionsRequest} from './model/GetTransactionsRequest';
 import {GetTransactionsResponse} from './model/GetTransactionsResponse';
 import {GetTransactionTreesResponse} from './model/GetTransactionTreesResponse';
@@ -108,6 +109,7 @@ export {
     GetTransactionTreesResponse,
     GetTransactionsRequest,
     GetTransactionResponse,
+    GetFlatTransactionResponse,
     GetTransactionByIdRequest,
     GetTimeResponse,
     GetLedgerIdentityResponse,

--- a/src/model/GetFlatTransactionResponse.ts
+++ b/src/model/GetFlatTransactionResponse.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {Transaction} from "./Transaction";
+
+export interface GetFlatTransactionResponse {
+    transaction: Transaction
+}

--- a/src/validation/GetFlatTransactionResponseValidation.ts
+++ b/src/validation/GetFlatTransactionResponseValidation.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetFlatTransactionResponse} from "../model/GetFlatTransactionResponse";
+import {noFields, RequiredFieldsValidators} from "./Validation";
+import {object} from "./Object";
+import {TransactionValidation} from "./TransactionValidation";
+
+function required(): RequiredFieldsValidators<GetFlatTransactionResponse> {
+    return {
+        transaction: TransactionValidation,
+    };
+}
+
+export const GetFlatTransactionResponseValidation = object<GetFlatTransactionResponse>('GetFlatTransactionResponse', required, noFields);

--- a/test/arbitrary/ArbitraryGetFlatTransactionResponse.ts
+++ b/test/arbitrary/ArbitraryGetFlatTransactionResponse.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as jsc from 'jsverify';
+import {ArbitraryTransaction} from './ArbitraryTransaction';
+import {GetFlatTransactionResponse} from "../../src/model/GetFlatTransactionResponse";
+
+export const ArbitraryGetFlatTransactionResponse: jsc.Arbitrary<GetFlatTransactionResponse> = ArbitraryTransaction.smap<GetFlatTransactionResponse>(
+    transaction => ({
+        transaction: transaction
+    }),
+    request => request.transaction
+);

--- a/test/client/DummyServer.ts
+++ b/test/client/DummyServer.ts
@@ -26,6 +26,7 @@ import {
 } from "../../src/generated/com/digitalasset/ledger/api/v1/package_service_pb";
 import {TransactionTree} from "../../src/generated/com/digitalasset/ledger/api/v1/transaction_pb";
 import {
+    GetFlatTransactionResponse,
     GetLedgerEndRequest,
     GetLedgerEndResponse,
     GetTransactionByEventIdRequest,
@@ -81,6 +82,8 @@ export class DummyServer extends Server {
 
         const getLedgerEndResponse = new GetLedgerEndResponse();
         getLedgerEndResponse.setOffset(offset);
+
+        const getFlatTransactionResponse = new GetFlatTransactionResponse();
 
         this.addService(ActiveContractsServiceService, {
             getActiveContracts(
@@ -271,6 +274,30 @@ export class DummyServer extends Server {
             ): void {
                 spy(call.request.getLedgerId());
                 callback(null, getLedgerEndResponse);
+            },
+            getFlatTransactionByEventId(
+                call: ServerUnaryCall<GetTransactionByEventIdRequest>,
+                callback: (
+                    error: ServiceError | null,
+                    value: GetFlatTransactionResponse | null,
+                    trailer?: Metadata,
+                    flags?: number
+                ) => void
+            ): void {
+                spy(call.request.getLedgerId());
+                callback(null, getFlatTransactionResponse);
+            },
+            getFlatTransactionById(
+                call: ServerUnaryCall<GetTransactionByIdRequest>,
+                callback: (
+                    error: ServiceError | null,
+                    value: GetFlatTransactionResponse | null,
+                    trailer?: Metadata,
+                    flags?: number
+                ) => void
+            ): void {
+                spy(call.request.getLedgerId());
+                callback(null, getFlatTransactionResponse);
             }
         });
 

--- a/test/client/DummyTransactionServiceClient.ts
+++ b/test/client/DummyTransactionServiceClient.ts
@@ -7,6 +7,7 @@ import {CallOptions, ClientReadableStream, ClientUnaryCall, Metadata} from 'grpc
 import {Timestamp} from 'google-protobuf/google/protobuf/timestamp_pb';
 import {ITransactionServiceClient} from "../../src/generated/com/digitalasset/ledger/api/v1/transaction_service_grpc_pb";
 import {
+    GetFlatTransactionResponse,
     GetLedgerEndRequest,
     GetLedgerEndResponse, GetTransactionByEventIdRequest, GetTransactionByIdRequest,
     GetTransactionResponse, GetTransactionsRequest, GetTransactionsResponse, GetTransactionTreesResponse
@@ -14,18 +15,20 @@ import {
 import {DummyClientReadableStream} from "../call/DummyClientReadableStream";
 import {DummyClientUnaryCall} from "../call/DummyClientUnaryCall";
 import {LedgerOffset} from "../../src/generated/com/digitalasset/ledger/api/v1/ledger_offset_pb";
-import {TransactionTree} from "../../src/generated/com/digitalasset/ledger/api/v1/transaction_pb";
+import {Transaction, TransactionTree} from "../../src/generated/com/digitalasset/ledger/api/v1/transaction_pb";
 
 export class DummyTransactionServiceClient implements ITransactionServiceClient {
     private readonly latestRequestSpy: sinon.SinonSpy;
 
     private readonly ledgerEndResponse = new GetLedgerEndResponse();
     private readonly transactionResponse = new GetTransactionResponse();
+    private readonly flatTransactionResponse = new GetFlatTransactionResponse();
 
     constructor(latestRequestSpy: sinon.SinonSpy) {
         this.latestRequestSpy = latestRequestSpy;
         this.initEmptyLedgerEndResponse();
         this.initEmptyTransactionResponse();
+        this.initEmptyFlatTransactionResponse();
     }
 
     getTransactions(
@@ -109,6 +112,94 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
                 : options
                 : callback;
         setImmediate(() => cb(null, this.transactionResponse));
+        return DummyClientUnaryCall.Instance;
+    }
+
+    getFlatTransactionByEventId(
+        request: GetTransactionByEventIdRequest,
+        callback: (
+            error: Error | null,
+            response: GetFlatTransactionResponse
+        ) => void
+    ): ClientUnaryCall;
+
+    getFlatTransactionByEventId(
+        request: GetTransactionByEventIdRequest,
+        metadata: Metadata,
+        callback: (
+            error: Error | null,
+            response: GetFlatTransactionResponse
+        ) => void
+    ): ClientUnaryCall;
+
+    getFlatTransactionByEventId(
+        request: GetTransactionByEventIdRequest,
+        metadata: Metadata,
+        options: Partial<CallOptions>,
+        callback: (
+            error: Error | null,
+            response: GetFlatTransactionResponse
+        ) => void
+    ): ClientUnaryCall;
+
+    getFlatTransactionByEventId(
+        request: GetTransactionByEventIdRequest,
+        metadata: any,
+        options?: any,
+        callback?: any
+    ) {
+        this.latestRequestSpy(request);
+        const cb =
+            callback === undefined
+                ? options === undefined
+                ? metadata
+                : options
+                : callback;
+        setImmediate(() => cb(null, this.flatTransactionResponse));
+        return DummyClientUnaryCall.Instance;
+    }
+
+    getFlatTransactionById(
+        request: GetTransactionByIdRequest,
+        callback: (
+            error: Error | null,
+            response: GetFlatTransactionResponse
+        ) => void
+    ): ClientUnaryCall;
+
+    getFlatTransactionById(
+        request: GetTransactionByIdRequest,
+        metadata: Metadata,
+        callback: (
+            error: Error | null,
+            response: GetFlatTransactionResponse
+        ) => void
+    ): ClientUnaryCall;
+
+    getFlatTransactionById(
+        request: GetTransactionByIdRequest,
+        metadata: Metadata,
+        options: Partial<CallOptions>,
+        callback: (
+            error: Error | null,
+            response: GetFlatTransactionResponse
+        ) => void
+    ): ClientUnaryCall;
+
+    getFlatTransactionById(
+        request: GetTransactionByIdRequest,
+        metadata: any,
+        options?: any,
+        callback?: any
+    ) {
+        this.latestRequestSpy(request);
+        const cb =
+            callback === undefined
+                ? options === undefined
+                ? metadata
+                : options
+                : callback;
+        setImmediate(() => cb(null, this.flatTransactionResponse));
         return DummyClientUnaryCall.Instance;
     }
 
@@ -207,4 +298,16 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
         tree.setTransactionId('mock');
         this.transactionResponse.setTransaction(tree);
     }
+
+    private initEmptyFlatTransactionResponse() {
+        const effectiveAt = new Timestamp();
+        effectiveAt.setSeconds(0);
+        effectiveAt.setNanos(0);
+        const transaction = new Transaction();
+        transaction.setEffectiveAt(effectiveAt);
+        transaction.setOffset('mock');
+        transaction.setTransactionId('mock');
+        this.flatTransactionResponse.setTransaction(transaction);
+    }
+
 }

--- a/test/client/TransactionClient.spec.ts
+++ b/test/client/TransactionClient.spec.ts
@@ -188,9 +188,39 @@ describe('TransactionClient', () => {
 
     });
 
+    it('should pass the requesting parties to the flat transaction lookup by event identifier endpoint', (done) => {
+
+        client.getFlatTransactionByEventId(transactionByEventIdRequest, (error, _response) => {
+            expect(error).to.be.null;
+            assert(latestRequestSpy.calledOnce);
+            expect(latestRequestSpy.lastCall.args).to.have.length(1);
+            expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByEventIdRequest);
+            const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByEventIdRequest;
+            expect(spiedRequest.getRequestingPartiesList()).to.have.lengthOf(2);
+            expect(spiedRequest.getRequestingPartiesList()![0]).to.equal('barbara');
+            expect(spiedRequest.getRequestingPartiesList()![1]).to.equal('samuel');
+            done();
+        });
+
+    });
+
     it('should pass the correct ledger identifier to the transaction lookup by event identifier endpoint', (done) => {
 
         client.getTransactionByEventId(transactionByEventIdRequest, (error, _response) => {
+            expect(error).to.be.null;
+            assert(latestRequestSpy.calledOnce);
+            expect(latestRequestSpy.lastCall.args).to.have.length(1);
+            expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByEventIdRequest);
+            const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByEventIdRequest;
+            expect(spiedRequest.getLedgerId()).to.equal(ledgerId);
+            done();
+        });
+
+    });
+
+    it('should pass the correct ledger identifier to the flat transaction lookup by event identifier endpoint', (done) => {
+
+        client.getFlatTransactionByEventId(transactionByEventIdRequest, (error, _response) => {
             expect(error).to.be.null;
             assert(latestRequestSpy.calledOnce);
             expect(latestRequestSpy.lastCall.args).to.have.length(1);
@@ -217,9 +247,38 @@ describe('TransactionClient', () => {
         });
     });
 
+    it('should pass the requesting parties to the flat transaction lookup by transaction identifier endpoint', (done) => {
+
+        client.getFlatTransactionById(transactionByIdRequest, (error, _response) => {
+            expect(error).to.be.null;
+            assert(latestRequestSpy.calledOnce);
+            expect(latestRequestSpy.lastCall.args).to.have.length(1);
+            expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByIdRequest);
+            const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByIdRequest;
+            expect(spiedRequest.getRequestingPartiesList()).to.have.lengthOf(2);
+            expect(spiedRequest.getRequestingPartiesList()![0]).to.equal('joel');
+            expect(spiedRequest.getRequestingPartiesList()![1]).to.equal('ethan');
+            done();
+        });
+    });
+
     it('should pass the correct ledger identifier to the transaction lookup by transaction identifier', (done) => {
 
         client.getTransactionById(transactionByIdRequest, (error, _response) => {
+            expect(error).to.be.null;
+            assert(latestRequestSpy.calledOnce);
+            expect(latestRequestSpy.lastCall.args).to.have.length(1);
+            expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByIdRequest);
+            const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByIdRequest;
+            expect(spiedRequest.getLedgerId()).to.equal(ledgerId);
+            done();
+        });
+
+    });
+
+    it('should pass the correct ledger identifier to the flat transaction lookup by transaction identifier', (done) => {
+
+        client.getFlatTransactionById(transactionByIdRequest, (error, _response) => {
             expect(error).to.be.null;
             assert(latestRequestSpy.calledOnce);
             expect(latestRequestSpy.lastCall.args).to.have.length(1);
@@ -240,6 +299,72 @@ describe('TransactionClient', () => {
             expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetLedgerEndRequest);
             const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetLedgerEndRequest;
             expect(spiedRequest.getLedgerId()).to.equal(ledgerId);
+            done();
+        });
+
+    });
+
+    it('should perform validation on the GetTransactionById endpoint', (done) => {
+
+        const invalidRequest = {
+            transactionId: 'some-tx-id',
+            requestingParties: 42
+        };
+
+        const expectedValidationTree: ValidationTree = {
+            errors: [],
+            children: {
+                transactionId: {
+                    errors: [],
+                    children: {}
+                },
+                requestingParties: {
+                    errors: [{
+                        errorType: 'type-error',
+                        expectedType: 'Array<string>',
+                        actualType: 'number'
+                    }],
+                    children: {}
+                }
+            }
+        };
+
+        client.getTransactionById(invalidRequest as any as GetTransactionByIdRequest, error => {
+            expect(error).to.not.be.null;
+            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTree);
+            done();
+        });
+
+    });
+
+    it('should perform validation on the GetFlatTransactionById endpoint', (done) => {
+
+        const invalidRequest = {
+            transactionId: 'some-tx-id',
+            requestingParties: 42
+        };
+
+        const expectedValidationTree: ValidationTree = {
+            errors: [],
+            children: {
+                transactionId: {
+                    errors: [],
+                    children: {}
+                },
+                requestingParties: {
+                    errors: [{
+                        errorType: 'type-error',
+                        expectedType: 'Array<string>',
+                        actualType: 'number'
+                    }],
+                    children: {}
+                }
+            }
+        };
+
+        client.getFlatTransactionById(invalidRequest as any as GetTransactionByIdRequest, error => {
+            expect(error).to.not.be.null;
+            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTree);
             done();
         });
 
@@ -268,9 +393,42 @@ describe('TransactionClient', () => {
                     children: {}
                 }
             }
-        }
+        };
 
         client.getTransactionByEventId(invalidRequest as any as GetTransactionByEventIdRequest, error => {
+            expect(error).to.not.be.null;
+            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTree);
+            done();
+        });
+
+    });
+
+    it('should perform validation on the GetFlatTransactionByEventId endpoint', (done) => {
+
+        const invalidRequest = {
+            eventId: 'some-event-id',
+            requestingParties: 42
+        };
+
+        const expectedValidationTree: ValidationTree = {
+            errors: [],
+            children: {
+                eventId: {
+                    errors: [],
+                    children: {}
+                },
+                requestingParties: {
+                    errors: [{
+                        errorType: 'type-error',
+                        expectedType: 'Array<string>',
+                        actualType: 'number'
+                    }],
+                    children: {}
+                }
+            }
+        };
+
+        client.getFlatTransactionByEventId(invalidRequest as any as GetTransactionByEventIdRequest, error => {
             expect(error).to.not.be.null;
             expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTree);
             done();

--- a/test/validation/AllObjects.spec.ts
+++ b/test/validation/AllObjects.spec.ts
@@ -88,6 +88,8 @@ import {GetPackageStatusResponseValidation} from "../../src/validation/GetPackag
 import {GetTimeResponseValidation} from "../../src/validation/GetTimeResponseValidation";
 import {ArbitraryCreateAndExerciseCommand} from "../arbitrary/ArbitraryCreateAndExerciseCommand";
 import {CreateAndExerciseCommandValidation} from "../../src/validation/CreateAndExerciseCommandValidation";
+import {GetFlatTransactionResponseValidation} from "../../src/validation/GetFlatTransactionResponseValidation";
+import {ArbitraryGetFlatTransactionResponse} from "../arbitrary/ArbitraryGetFlatTransactionResponse";
 
 function test<A extends { [_: string]: any }>(
     validation: ObjectValidation<A>,
@@ -230,6 +232,7 @@ test(
     ArbitraryGetTransactionByEventIdRequest
 );
 test(GetTransactionByIdRequestValidation, ArbitraryGetTransactionByIdRequest);
+test(GetFlatTransactionResponseValidation, ArbitraryGetFlatTransactionResponse);
 test(GetTransactionResponseValidation, ArbitraryGetTransactionResponse);
 test(GetTransactionsRequestValidation, ArbitraryGetTransactionsRequest);
 test(GetTransactionsResponseValidation, ArbitraryGetTransactionsResponse);


### PR DESCRIPTION
Fixes #18

This contribution also includes an issue found while development, namely
the fact that input validation was not run on the GetTransactionById
endpoint of the TransactionService.