### PR TITLE
Issue 65 blackduck scan for daml-js

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ steps:
       versionSpec: $(nodejs_version)
   - script: npm run ci-pipeline
     displayName: Build and test
-  - bash: bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml-js master --logging.level.com.synopsys.integration=DEBUG --detect.tools.excluded=POLARIS --detect.python.python3=true
+  - bash: bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml-js master --logging.level.com.synopsys.integration=DEBUG
     displayName: 'Blackduck Scan'
     env:
       BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,13 +28,17 @@ strategy:
       daml_sdk_version: 0.12.16
 
 steps:
-- script: curl -sSL https://get.daml.com/ | sh
-  displayName: Get DAML SDK installer
-- script: ~/.daml/bin/daml install $(daml_sdk_version)
-  displayName: Install DAML SDK $(daml_sdk_version)
-- task: NodeTool@0
-  displayName: Install Node.js $(nodejs_version)
-  inputs:
-    versionSpec: $(nodejs_version)
-- script: npm run ci-pipeline
-  displayName: Build and test
+  - script: curl -sSL https://get.daml.com/ | sh
+    displayName: Get DAML SDK installer
+  - script: ~/.daml/bin/daml install $(daml_sdk_version)
+    displayName: Install DAML SDK $(daml_sdk_version)
+  - task: NodeTool@0
+    displayName: Install Node.js $(nodejs_version)
+    inputs:
+      versionSpec: $(nodejs_version)
+  - script: npm run ci-pipeline
+    displayName: Build and test
+  - bash: <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml-js master --logging.level.com.synopsys.integration=DEBUG --detect.python.python3=true
+    displayName: 'Blackduck Scan'
+    env:
+      BLACKDUCK_HUB_CREDENTIALS: $(BLACKDUCK_HUB_CREDENTIALS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,16 +28,16 @@ strategy:
       daml_sdk_version: 0.12.16
 
 steps:
-#  - script: curl -sSL https://get.daml.com/ | sh
-#    displayName: Get DAML SDK installer
-#  - script: ~/.daml/bin/daml install $(daml_sdk_version)
-#    displayName: Install DAML SDK $(daml_sdk_version)
-#  - task: NodeTool@0
-#    displayName: Install Node.js $(nodejs_version)
-#    inputs:
-#      versionSpec: $(nodejs_version)
-#  - script: npm run ci-pipeline
-#    displayName: Build and test
+  - script: curl -sSL https://get.daml.com/ | sh
+    displayName: Get DAML SDK installer
+  - script: ~/.daml/bin/daml install $(daml_sdk_version)
+    displayName: Install DAML SDK $(daml_sdk_version)
+  - task: NodeTool@0
+    displayName: Install Node.js $(nodejs_version)
+    inputs:
+      versionSpec: $(nodejs_version)
+  - script: npm run ci-pipeline
+    displayName: Build and test
   - bash: bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml-js master --logging.level.com.synopsys.integration=DEBUG --detect.tools.excluded=POLARIS --detect.python.python3=true
     displayName: 'Blackduck Scan'
     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,4 +41,4 @@ steps:
   - bash: bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml-js master --logging.level.com.synopsys.integration=DEBUG --detect.python.python3=true
     displayName: 'Blackduck Scan'
     env:
-      BLACKDUCK_HUB_CREDENTIALS: $(BLACKDUCK_HUB_CREDENTIALS)
+      BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUB_CREDENTIALS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,17 +28,17 @@ strategy:
       daml_sdk_version: 0.12.16
 
 steps:
-  - script: curl -sSL https://get.daml.com/ | sh
-    displayName: Get DAML SDK installer
-  - script: ~/.daml/bin/daml install $(daml_sdk_version)
-    displayName: Install DAML SDK $(daml_sdk_version)
-  - task: NodeTool@0
-    displayName: Install Node.js $(nodejs_version)
-    inputs:
-      versionSpec: $(nodejs_version)
-  - script: npm run ci-pipeline
-    displayName: Build and test
-  - bash: <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml-js master --logging.level.com.synopsys.integration=DEBUG --detect.python.python3=true
+#  - script: curl -sSL https://get.daml.com/ | sh
+#    displayName: Get DAML SDK installer
+#  - script: ~/.daml/bin/daml install $(daml_sdk_version)
+#    displayName: Install DAML SDK $(daml_sdk_version)
+#  - task: NodeTool@0
+#    displayName: Install Node.js $(nodejs_version)
+#    inputs:
+#      versionSpec: $(nodejs_version)
+#  - script: npm run ci-pipeline
+#    displayName: Build and test
+  - bash: bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml-js master --logging.level.com.synopsys.integration=DEBUG --detect.python.python3=true
     displayName: 'Blackduck Scan'
     env:
       BLACKDUCK_HUB_CREDENTIALS: $(BLACKDUCK_HUB_CREDENTIALS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ steps:
 #      versionSpec: $(nodejs_version)
 #  - script: npm run ci-pipeline
 #    displayName: Build and test
-  - bash: bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml-js master --logging.level.com.synopsys.integration=DEBUG --detect.python.python3=true
+  - bash: bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml-js master --logging.level.com.synopsys.integration=DEBUG --detect.tools.excluded=POLARIS --detect.python.python3=true
     displayName: 'Blackduck Scan'
     env:
-      BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUB_CREDENTIALS)
+      BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)


### PR DESCRIPTION
#65 Enable blackduck security vulnerability and licensing scan for dependencies within `daml-js`

