### PR TITLE
Promisify all the things

### DIFF
--- a/src/client/ActiveContractsClient.ts
+++ b/src/client/ActiveContractsClient.ts
@@ -1,32 +1,16 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {IActiveContractsServiceClient} from '../generated/com/digitalasset/ledger/api/v1/active_contracts_service_grpc_pb';
 import {GetActiveContractsRequest} from "../model/GetActiveContractsRequest";
 import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
 import {GetActiveContractsResponse} from "../model/GetActiveContractsResponse";
-import {GetActiveContractsRequestValidation} from "../validation/GetActiveContractsRequestValidation";
-import {isValid} from "../validation/Validation";
-import {GetActiveContractsResponseCodec} from "../codec/GetActiveContractsResponseCodec";
-import {GetActiveContractsRequestCodec} from "../codec/GetActiveContractsRequestCodec";
-import {ValidationReporter} from "../reporting/ValidationReporter";
 
 /**
  * Allows clients to initialize themselves according to a fairly recent state
  * of the ledger without reading through all transactions that were committed
  * since the ledger's creation.
  */
-export class ActiveContractsClient {
-
-    private readonly ledgerId: string;
-    private readonly client: IActiveContractsServiceClient;
-    private readonly reporter: ValidationReporter;
-
-    constructor(ledgerId: string, client: IActiveContractsServiceClient, reporter: ValidationReporter) {
-        this.ledgerId = ledgerId;
-        this.client = client;
-        this.reporter = reporter;
-    }
+export interface ActiveContractsClient {
 
     /**
      * Returns a stream of the latest snapshot of active contracts. Getting an
@@ -36,18 +20,6 @@ export class ActiveContractsClient {
      * Clients SHOULD NOT assume that the set of active contracts they receive
      * reflects the state at the ledger end.
      */
-    getActiveContracts(requestObject: GetActiveContractsRequest): ClientReadableObjectStream<GetActiveContractsResponse> {
-        const tree = GetActiveContractsRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = GetActiveContractsRequestCodec.serialize(requestObject);
-            request.setLedgerId(this.ledgerId);
-            if (requestObject.verbose === undefined) {
-                request.setVerbose(true);
-            }
-            return ClientReadableObjectStream.from(this.client.getActiveContracts(request), GetActiveContractsResponseCodec);
-        } else {
-            return ClientReadableObjectStream.from(new Error(this.reporter.render(tree)));
-        }
-    }
+    getActiveContracts(requestObject: GetActiveContractsRequest): ClientReadableObjectStream<GetActiveContractsResponse>
 
 }

--- a/src/client/CommandClient.ts
+++ b/src/client/CommandClient.ts
@@ -1,37 +1,19 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {Callback, forward, justForward} from "../util/Callback";
+import {Callback} from "../util/Callback";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
-import {ICommandServiceClient} from "../generated/com/digitalasset/ledger/api/v1/command_service_grpc_pb";
-import {ValidationReporter} from "../reporting/ValidationReporter";
 import {SubmitAndWaitRequest} from "../model/SubmitAndWaitRequest";
-import {SubmitAndWaitRequestValidation} from "../validation/SubmitAndWaitRequestValidation";
-import {isValid} from "../validation/Validation";
-import {SubmitAndWaitRequestCodec} from "../codec/SubmitAndWaitRequestCodec";
 import {SubmitAndWaitForTransactionResponse} from "../model/SubmitAndWaitForTransactionResponse";
-import {SubmitAndWaitForTransactionResponseCodec} from "../codec/SubmitAndWaitForTransactionResponseCodec";
 import {SubmitAndWaitForTransactionIdResponse} from "../model/SubmitAndWaitForTransactionIdResponse";
-import {SubmitAndWaitForTransactionIdResponseCodec} from "../codec/SubmitAndWaitForTransactionIdResponseCodec";
 import {SubmitAndWaitForTransactionTreeResponse} from "../model/SubmitAndWaitForTransactionTreeResponse";
-import {SubmitAndWaitForTransactionTreeResponseCodec} from "../codec/SubmitAndWaitForTransactionTreeResponseCodec";
 
 /**
  * Command Service is able to correlate submitted commands with completion
  * ledger, identify timeouts, and return contextual information with each
  * tracking result. This supports the implementation of stateless clients.
  */
-export class CommandClient {
-
-    private readonly ledgerId: string;
-    private readonly client: ICommandServiceClient;
-    private readonly reporter: ValidationReporter;
-
-    constructor(ledgerId: string, client: ICommandServiceClient, reporter: ValidationReporter) {
-        this.ledgerId = ledgerId;
-        this.client = client;
-        this.reporter = reporter;
-    }
+export interface CommandClient {
 
     /**
      * Submits a single composite command and waits for its result.
@@ -42,19 +24,8 @@ export class CommandClient {
      * Propagates the gRPC error of failed submissions including DAML
      * interpretation errors.
      */
-    submitAndWait(requestObject: SubmitAndWaitRequest, callback: Callback<null>): ClientCancellableCall {
-        const tree = SubmitAndWaitRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = SubmitAndWaitRequestCodec.serialize(requestObject);
-            request.getCommands()!.setLedgerId(this.ledgerId);
-            return ClientCancellableCall.accept(this.client.submitAndWait(request, (error, _) => {
-                justForward(callback, error, null)
-            }));
-        } else {
-            setImmediate(() => callback(new Error(this.reporter.render(tree))));
-            return ClientCancellableCall.rejected;
-        }
-    }
+    submitAndWait(requestObject: SubmitAndWaitRequest): Promise<null>
+    submitAndWait(requestObject: SubmitAndWaitRequest, callback: Callback<null>): ClientCancellableCall
 
     /**
      * Submits a single composite command, waits for its result, and returns the transaction.
@@ -63,19 +34,8 @@ export class CommandClient {
      *
      * Propagates the gRPC error of failed submissions including DAML interpretation errors.
      */
-    submitAndWaitForTransaction(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionResponse>): ClientCancellableCall {
-        const tree = SubmitAndWaitRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = SubmitAndWaitRequestCodec.serialize(requestObject);
-            request.getCommands()!.setLedgerId(this.ledgerId);
-            return ClientCancellableCall.accept(this.client.submitAndWaitForTransaction(request, (error, response) => {
-                forward(callback, error, response, SubmitAndWaitForTransactionResponseCodec.deserialize);
-            }));
-        } else {
-            setImmediate(() => callback(new Error(this.reporter.render(tree))));
-            return ClientCancellableCall.rejected;
-        }
-    }
+    submitAndWaitForTransaction(requestObject: SubmitAndWaitRequest): Promise<SubmitAndWaitForTransactionResponse>
+    submitAndWaitForTransaction(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionResponse>): ClientCancellableCall
 
     /**
      * Submits a single composite command, waits for its result, and returns the transaction id.
@@ -84,19 +44,8 @@ export class CommandClient {
      *
      * Propagates the gRPC error of failed submissions including DAML interpretation errors.
      */
-    submitAndWaitForTransactionId(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionIdResponse>): ClientCancellableCall {
-        const tree = SubmitAndWaitRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = SubmitAndWaitRequestCodec.serialize(requestObject);
-            request.getCommands()!.setLedgerId(this.ledgerId);
-            return ClientCancellableCall.accept(this.client.submitAndWaitForTransactionId(request, (error, response) => {
-                forward(callback, error, response, SubmitAndWaitForTransactionIdResponseCodec.deserialize);
-            }));
-        } else {
-            setImmediate(() => callback(new Error(this.reporter.render(tree))));
-            return ClientCancellableCall.rejected;
-        }
-    }
+    submitAndWaitForTransactionId(requestObject: SubmitAndWaitRequest): Promise<SubmitAndWaitForTransactionIdResponse>
+    submitAndWaitForTransactionId(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionIdResponse>): ClientCancellableCall
 
     /**
      * Submits a single composite command, waits for its result, and returns the transaction tree.
@@ -105,18 +54,7 @@ export class CommandClient {
      *
      * Propagates the gRPC error of failed submissions including DAML interpretation errors.
      */
-    submitAndWaitForTransactionTree(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionTreeResponse>): ClientCancellableCall {
-        const tree = SubmitAndWaitRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = SubmitAndWaitRequestCodec.serialize(requestObject);
-            request.getCommands()!.setLedgerId(this.ledgerId);
-            return ClientCancellableCall.accept(this.client.submitAndWaitForTransactionTree(request, (error, response) => {
-                forward(callback, error, response, SubmitAndWaitForTransactionTreeResponseCodec.deserialize);
-            }));
-        } else {
-            setImmediate(() => callback(new Error(this.reporter.render(tree))));
-            return ClientCancellableCall.rejected;
-        }
-    }
+    submitAndWaitForTransactionTree(requestObject: SubmitAndWaitRequest): Promise<SubmitAndWaitForTransactionTreeResponse>
+    submitAndWaitForTransactionTree(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionTreeResponse>): ClientCancellableCall
 
 }

--- a/src/client/CommandClient.ts
+++ b/src/client/CommandClient.ts
@@ -24,8 +24,8 @@ export interface CommandClient {
      * Propagates the gRPC error of failed submissions including DAML
      * interpretation errors.
      */
-    submitAndWait(requestObject: SubmitAndWaitRequest): Promise<null>
-    submitAndWait(requestObject: SubmitAndWaitRequest, callback: Callback<null>): ClientCancellableCall
+    submitAndWait(requestObject: SubmitAndWaitRequest): Promise<void>
+    submitAndWait(requestObject: SubmitAndWaitRequest, callback: Callback<void>): ClientCancellableCall
 
     /**
      * Submits a single composite command, waits for its result, and returns the transaction.

--- a/src/client/CommandCompletionClient.ts
+++ b/src/client/CommandCompletionClient.ts
@@ -1,19 +1,11 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ICommandCompletionServiceClient} from "../generated/com/digitalasset/ledger/api/v1/command_completion_service_grpc_pb";
-import {ValidationReporter} from "../reporting/ValidationReporter";
-import {CompletionEndRequest} from "../generated/com/digitalasset/ledger/api/v1/command_completion_service_pb";
 import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
 import {CompletionStreamResponse} from "../model/CompletionStreamResponse";
-import {CompletionStreamRequestValidation} from "../validation/CompletionStreamRequestValidation";
-import {Callback, forward} from "../util/Callback";
+import {Callback} from "../util/Callback";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
-import {CompletionEndResponseCodec} from "../codec/CompletionEndResponseCodec";
 import {CompletionEndResponse} from "../model/CompletionEndResponse";
-import {CompletionStreamResponseCodec} from "../codec/CompletionStreamResponseCodec";
-import {isValid} from "../validation/Validation";
-import {CompletionStreamRequestCodec} from "../codec/CompletionStreamRequestCodec";
 import {CompletionStreamRequest} from "../model/CompletionStreamRequest";
 
 /**
@@ -49,42 +41,17 @@ import {CompletionStreamRequest} from "../model/CompletionStreamRequest";
  * The server will return a child context of the submitted one, (or a new
  * one if the context was missing) on both the CompletionValidation and TransactionValidation streams.
  */
-export class CommandCompletionClient {
-
-    private readonly completionEndRequest: CompletionEndRequest;
-    private readonly client: ICommandCompletionServiceClient;
-    private readonly ledgerId: string;
-    private readonly reporter: ValidationReporter
-
-    constructor(ledgerId: string, client: ICommandCompletionServiceClient, reporter: ValidationReporter) {
-        this.completionEndRequest = new CompletionEndRequest();
-        this.completionEndRequest.setLedgerId(ledgerId);
-        this.ledgerId = ledgerId;
-        this.client = client;
-        this.reporter = reporter;
-    }
+export interface CommandCompletionClient {
 
     /**
      * Subscribe to command completion events.
      */
-    completionStream(requestObject: CompletionStreamRequest): ClientReadableObjectStream<CompletionStreamResponse> {
-        const tree = CompletionStreamRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = CompletionStreamRequestCodec.serialize(requestObject);
-            request.setLedgerId(this.ledgerId);
-            return ClientReadableObjectStream.from(this.client.completionStream(request), CompletionStreamResponseCodec);
-        } else {
-            return ClientReadableObjectStream.from(new Error(this.reporter.render(tree)));
-        }
-    }
+    completionStream(requestObject: CompletionStreamRequest): ClientReadableObjectStream<CompletionStreamResponse>
 
     /**
      * Returns the offset after the latest completion.
      */
-    completionEnd(callback: Callback<CompletionEndResponse>): ClientCancellableCall {
-        return ClientCancellableCall.accept(this.client.completionEnd(this.completionEndRequest, (error, response) => {
-            forward(callback, error, response, CompletionEndResponseCodec.deserialize);
-        }));
-    }
+    completionEnd(): Promise<CompletionEndResponse>
+    completionEnd(callback: Callback<CompletionEndResponse>): ClientCancellableCall
 
 }

--- a/src/client/CommandSubmissionClient.ts
+++ b/src/client/CommandSubmissionClient.ts
@@ -46,7 +46,7 @@ export interface CommandSubmissionClient {
     /**
      * Submit a single composite command.
      */
-    submit(requestObject: SubmitRequest): Promise<null>
-    submit(requestObject: SubmitRequest, callback: Callback<null>): ClientCancellableCall
+    submit(requestObject: SubmitRequest): Promise<void>
+    submit(requestObject: SubmitRequest, callback: Callback<void>): ClientCancellableCall
 
 }

--- a/src/client/CommandSubmissionClient.ts
+++ b/src/client/CommandSubmissionClient.ts
@@ -1,14 +1,9 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {SubmitRequestValidation} from "../validation/SubmitRequestValidation";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
-import {Callback, justForward} from "../util/Callback";
-import {ValidationReporter} from "../reporting/ValidationReporter";
-import {ICommandSubmissionServiceClient} from "../generated/com/digitalasset/ledger/api/v1/command_submission_service_grpc_pb";
+import {Callback} from "../util/Callback";
 import {SubmitRequest} from "../model/SubmitRequest";
-import {isValid} from "../validation/Validation";
-import {SubmitRequestCodec} from "../codec/SubmitRequestCodec";
 
 /**
  * Allows clients to attempt advancing the ledger's state by submitting
@@ -46,35 +41,12 @@ import {SubmitRequestCodec} from "../codec/SubmitRequestCodec";
  * one if the context was missing) on both the CompletionValidation and TransactionValidation
  * streams.
  */
-export class CommandSubmissionClient {
-
-    private readonly ledgerId: string;
-    private readonly client: ICommandSubmissionServiceClient;
-    private readonly reporter: ValidationReporter;
-
-    constructor(ledgerId: string, client: ICommandSubmissionServiceClient, reporter: ValidationReporter) {
-        this.ledgerId = ledgerId;
-        this.client = client;
-        this.reporter = reporter;
-    }
+export interface CommandSubmissionClient {
 
     /**
      * Submit a single composite command.
      */
-    submit(requestObject: SubmitRequest, callback: Callback<null>): ClientCancellableCall {
-        const tree = SubmitRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = SubmitRequestCodec.serialize(requestObject);
-            if (request.hasCommands()) {
-                request.getCommands()!.setLedgerId(this.ledgerId);
-            }
-            return ClientCancellableCall.accept(this.client.submit(request, (error, _) => {
-                justForward(callback, error, null);
-            }));
-        } else {
-            setImmediate(() => callback(new Error(this.reporter.render(tree))));
-            return ClientCancellableCall.rejected;
-        }
-    }
+    submit(requestObject: SubmitRequest): Promise<null>
+    submit(requestObject: SubmitRequest, callback: Callback<null>): ClientCancellableCall
 
 }

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -29,6 +29,7 @@ import {LedgerConfigurationServiceClient} from "../generated/com/digitalasset/le
 import {TimeServiceClient} from "../generated/com/digitalasset/ledger/api/v1/testing/time_service_grpc_pb";
 import {TransactionServiceClient} from "../generated/com/digitalasset/ledger/api/v1/transaction_service_grpc_pb";
 import {ResetServiceClient} from "../generated/com/digitalasset/ledger/api/v1/testing/reset_service_grpc_pb";
+import {NodeJsCommandClient} from "./NodeJsCommandClient";
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -60,7 +61,7 @@ export class DamlLedgerClient implements LedgerClient {
             new ActiveContractsServiceClient(address, credentials),
             reporter
         );
-        this._commandClient = new CommandClient(
+        this._commandClient = new NodeJsCommandClient(
             ledgerId,
             new CommandServiceClient(address, credentials),
             reporter

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -15,7 +15,7 @@ import {TransactionClient} from "./TransactionClient";
 import {TimeClient} from "./TimeClient";
 import {LedgerConfigurationClient} from "./LedgerConfigurationClient";
 import {PackageClient} from "./PackageClient";
-import {LedgerIdentityClient} from "./LedgerIdentityClient";
+import {NodeJsLedgerIdentityClient} from "./NodeJsLedgerIdentityClient";
 import {NodeJsCommandSubmissionClient} from "./NodeJsCommandSubmissionClient";
 
 import {LedgerIdentityServiceClient} from "../generated/com/digitalasset/ledger/api/v1/ledger_identity_service_grpc_pb";
@@ -34,6 +34,7 @@ import {NodeJsActiveContractsClient} from "./NodeJsActiveContractsClient";
 import {NodeJsCommandCompletionClient} from "./NodeJsCommandCompletionClient";
 import {CommandSubmissionClient} from "./CommandSubmissionClient";
 import {NodeJsLedgerConfigurationClient} from "./NodeJsLedgerConfigurationClient";
+import {LedgerIdentityClient} from "./LedgerIdentityClient";
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -80,7 +81,7 @@ export class DamlLedgerClient implements LedgerClient {
             new CommandSubmissionServiceClient(address, credentials),
             reporter
         );
-        this._ledgerIdentityClient = new LedgerIdentityClient(
+        this._ledgerIdentityClient = new NodeJsLedgerIdentityClient(
             new LedgerIdentityServiceClient(address, credentials)
         );
         this._packageClient = new PackageClient(

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -16,7 +16,7 @@ import {TimeClient} from "./TimeClient";
 import {LedgerConfigurationClient} from "./LedgerConfigurationClient";
 import {PackageClient} from "./PackageClient";
 import {LedgerIdentityClient} from "./LedgerIdentityClient";
-import {CommandSubmissionClient} from "./CommandSubmissionClient";
+import {NodeJsCommandSubmissionClient} from "./NodeJsCommandSubmissionClient";
 
 import {LedgerIdentityServiceClient} from "../generated/com/digitalasset/ledger/api/v1/ledger_identity_service_grpc_pb";
 import {GetLedgerIdentityRequest} from "../generated/com/digitalasset/ledger/api/v1/ledger_identity_service_pb";
@@ -32,6 +32,7 @@ import {ResetServiceClient} from "../generated/com/digitalasset/ledger/api/v1/te
 import {NodeJsCommandClient} from "./NodeJsCommandClient";
 import {NodeJsActiveContractsClient} from "./NodeJsActiveContractsClient";
 import {NodeJsCommandCompletionClient} from "./NodeJsCommandCompletionClient";
+import {CommandSubmissionClient} from "./CommandSubmissionClient";
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -73,7 +74,7 @@ export class DamlLedgerClient implements LedgerClient {
             new CommandCompletionServiceClient(address, credentials),
             reporter
         );
-        this._commandSubmissionClient = new CommandSubmissionClient(
+        this._commandSubmissionClient = new NodeJsCommandSubmissionClient(
             ledgerId,
             new CommandSubmissionServiceClient(address, credentials),
             reporter

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -33,6 +33,7 @@ import {NodeJsCommandClient} from "./NodeJsCommandClient";
 import {NodeJsActiveContractsClient} from "./NodeJsActiveContractsClient";
 import {NodeJsCommandCompletionClient} from "./NodeJsCommandCompletionClient";
 import {CommandSubmissionClient} from "./CommandSubmissionClient";
+import {NodeJsLedgerConfigurationClient} from "./NodeJsLedgerConfigurationClient";
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -86,7 +87,7 @@ export class DamlLedgerClient implements LedgerClient {
             ledgerId,
             new PackageServiceClient(address, credentials)
         );
-        this._ledgerConfigurationClient = new LedgerConfigurationClient(
+        this._ledgerConfigurationClient = new NodeJsLedgerConfigurationClient(
             ledgerId,
             new LedgerConfigurationServiceClient(address, credentials)
         );

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -30,6 +30,7 @@ import {TimeServiceClient} from "../generated/com/digitalasset/ledger/api/v1/tes
 import {TransactionServiceClient} from "../generated/com/digitalasset/ledger/api/v1/transaction_service_grpc_pb";
 import {ResetServiceClient} from "../generated/com/digitalasset/ledger/api/v1/testing/reset_service_grpc_pb";
 import {NodeJsCommandClient} from "./NodeJsCommandClient";
+import {NodeJsActiveContractsClient} from "./NodeJsActiveContractsClient";
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -56,7 +57,7 @@ export class DamlLedgerClient implements LedgerClient {
         reporter: ValidationReporter
     ) {
         this.ledgerId = ledgerId;
-        this._activeContractsClient = new ActiveContractsClient(
+        this._activeContractsClient = new NodeJsActiveContractsClient(
             ledgerId,
             new ActiveContractsServiceClient(address, credentials),
             reporter

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -38,6 +38,7 @@ import {LedgerIdentityClient} from "./LedgerIdentityClient";
 import {PackageClient} from "./PackageClient";
 import {promisify} from "util";
 import {ResetClient} from "./ResetClient";
+import {NodeJsTimeClient} from "./NodeJsTimeClient";
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -95,7 +96,7 @@ export class DamlLedgerClient implements LedgerClient {
             ledgerId,
             new LedgerConfigurationServiceClient(address, credentials)
         );
-        this._timeClient = new TimeClient(
+        this._timeClient = new NodeJsTimeClient(
             ledgerId,
             new TimeServiceClient(address, credentials),
             reporter
@@ -194,7 +195,7 @@ export class DamlLedgerClient implements LedgerClient {
         );
     }
 
-    private static connectPromise: (_: LedgerClientOptions) => Promise<LedgerClient> = promisify(DamlLedgerClient.connectCallback) as (_: LedgerClientOptions) => Promise<LedgerClient>
+    private static connectPromise: (_: LedgerClientOptions) => Promise<LedgerClient> = promisify(DamlLedgerClient.connectCallback) as (_: LedgerClientOptions) => Promise<LedgerClient>;
 
     static connect(options: LedgerClientOptions): Promise<LedgerClient>
     static connect(options: LedgerClientOptions, callback: Callback<LedgerClient>): void

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -31,6 +31,7 @@ import {TransactionServiceClient} from "../generated/com/digitalasset/ledger/api
 import {ResetServiceClient} from "../generated/com/digitalasset/ledger/api/v1/testing/reset_service_grpc_pb";
 import {NodeJsCommandClient} from "./NodeJsCommandClient";
 import {NodeJsActiveContractsClient} from "./NodeJsActiveContractsClient";
+import {NodeJsCommandCompletionClient} from "./NodeJsCommandCompletionClient";
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -67,7 +68,7 @@ export class DamlLedgerClient implements LedgerClient {
             new CommandServiceClient(address, credentials),
             reporter
         );
-        this._commandCompletionClient = new CommandCompletionClient(
+        this._commandCompletionClient = new NodeJsCommandCompletionClient(
             ledgerId,
             new CommandCompletionServiceClient(address, credentials),
             reporter

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -10,7 +10,7 @@ import {ActiveContractsClient} from "./ActiveContractsClient";
 import {CommandClient} from "./CommandClient";
 import {ValidationReporter} from "../reporting/ValidationReporter";
 import {CommandCompletionClient} from "./CommandCompletionClient";
-import {ResetClient} from "./ResetClient";
+import {NodeJsResetClient} from "./NodeJsResetClient";
 import {TransactionClient} from "./TransactionClient";
 import {TimeClient} from "./TimeClient";
 import {LedgerConfigurationClient} from "./LedgerConfigurationClient";
@@ -37,6 +37,7 @@ import {NodeJsLedgerConfigurationClient} from "./NodeJsLedgerConfigurationClient
 import {LedgerIdentityClient} from "./LedgerIdentityClient";
 import {PackageClient} from "./PackageClient";
 import {promisify} from "util";
+import {ResetClient} from "./ResetClient";
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -104,7 +105,7 @@ export class DamlLedgerClient implements LedgerClient {
             new TransactionServiceClient(address, credentials),
             reporter
         );
-        this._resetClient = new ResetClient(
+        this._resetClient = new NodeJsResetClient(
             ledgerId,
             new ResetServiceClient(address, credentials)
         );

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -35,6 +35,7 @@ import {NodeJsCommandCompletionClient} from "./NodeJsCommandCompletionClient";
 import {CommandSubmissionClient} from "./CommandSubmissionClient";
 import {NodeJsLedgerConfigurationClient} from "./NodeJsLedgerConfigurationClient";
 import {LedgerIdentityClient} from "./LedgerIdentityClient";
+import {promisify} from "util";
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -148,13 +149,7 @@ export class DamlLedgerClient implements LedgerClient {
         return this._resetClient;
     }
 
-    /**
-     * Connects a new instance of the {@link DamlLedgerClient} to the
-     *
-     * @param options The host, port and certificates needed to reach the ledger
-     * @param callback A callback that will be either passed an error or the LedgerClient instance in case of successful connection
-     */
-    static connect(
+    private static connectCallback(
         options: LedgerClientOptions,
         callback: Callback<LedgerClient>
     ): void {
@@ -195,5 +190,13 @@ export class DamlLedgerClient implements LedgerClient {
                 });
             }
         );
+    }
+
+    private static connectPromise: (_: LedgerClientOptions) => Promise<LedgerClient> = promisify(DamlLedgerClient.connectCallback) as (_: LedgerClientOptions) => Promise<LedgerClient>
+
+    static connect(options: LedgerClientOptions): Promise<LedgerClient>
+    static connect(options: LedgerClientOptions, callback: Callback<LedgerClient>): void
+    static connect(options: LedgerClientOptions, callback?: Callback<LedgerClient>): void | Promise<LedgerClient> {
+        return callback ? DamlLedgerClient.connectCallback(options, callback) : DamlLedgerClient.connectPromise(options);
     }
 }

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -14,7 +14,7 @@ import {ResetClient} from "./ResetClient";
 import {TransactionClient} from "./TransactionClient";
 import {TimeClient} from "./TimeClient";
 import {LedgerConfigurationClient} from "./LedgerConfigurationClient";
-import {PackageClient} from "./PackageClient";
+import {NodeJsPackageClient} from "./NodeJsPackageClient";
 import {NodeJsLedgerIdentityClient} from "./NodeJsLedgerIdentityClient";
 import {NodeJsCommandSubmissionClient} from "./NodeJsCommandSubmissionClient";
 
@@ -35,6 +35,7 @@ import {NodeJsCommandCompletionClient} from "./NodeJsCommandCompletionClient";
 import {CommandSubmissionClient} from "./CommandSubmissionClient";
 import {NodeJsLedgerConfigurationClient} from "./NodeJsLedgerConfigurationClient";
 import {LedgerIdentityClient} from "./LedgerIdentityClient";
+import {PackageClient} from "./PackageClient";
 import {promisify} from "util";
 
 /**
@@ -85,7 +86,7 @@ export class DamlLedgerClient implements LedgerClient {
         this._ledgerIdentityClient = new NodeJsLedgerIdentityClient(
             new LedgerIdentityServiceClient(address, credentials)
         );
-        this._packageClient = new PackageClient(
+        this._packageClient = new NodeJsPackageClient(
             ledgerId,
             new PackageServiceClient(address, credentials)
         );

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -198,9 +198,16 @@ export class DamlLedgerClient implements LedgerClient {
 
     private static connectPromise: (_: LedgerClientOptions) => Promise<LedgerClient> = promisify(DamlLedgerClient.connectCallback) as (_: LedgerClientOptions) => Promise<LedgerClient>;
 
+    /**
+     * Connects a new instance of the {@link DamlLedgerClient} to the
+     *
+     * @param options The host, port and certificates needed to reach the ledger
+     * @param callback A callback that will be either passed an error or the LedgerClient instance in case of successful connection
+     */
     static connect(options: LedgerClientOptions): Promise<LedgerClient>
     static connect(options: LedgerClientOptions, callback: Callback<LedgerClient>): void
     static connect(options: LedgerClientOptions, callback?: Callback<LedgerClient>): void | Promise<LedgerClient> {
         return callback ? DamlLedgerClient.connectCallback(options, callback) : DamlLedgerClient.connectPromise(options);
     }
+
 }

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -39,6 +39,7 @@ import {PackageClient} from "./PackageClient";
 import {promisify} from "util";
 import {ResetClient} from "./ResetClient";
 import {NodeJsTimeClient} from "./NodeJsTimeClient";
+import {NodeJsTransactionClient} from "./NodeJsTransactionClient";
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -101,7 +102,7 @@ export class DamlLedgerClient implements LedgerClient {
             new TimeServiceClient(address, credentials),
             reporter
         );
-        this._transactionClient = new TransactionClient(
+        this._transactionClient = new NodeJsTransactionClient(
             ledgerId,
             new TransactionServiceClient(address, credentials),
             reporter

--- a/src/client/LedgerConfigurationClient.ts
+++ b/src/client/LedgerConfigurationClient.ts
@@ -2,32 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-import {GetLedgerConfigurationRequest} from "../generated/com/digitalasset/ledger/api/v1/ledger_configuration_service_pb";
-import {ILedgerConfigurationServiceClient} from "../generated/com/digitalasset/ledger/api/v1/ledger_configuration_service_grpc_pb";
 import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
 import {GetLedgerConfigurationResponse} from "../model/GetLedgerConfigurationResponse";
-import {GetLedgerConfigurationResponseCodec} from "../codec/GetLedgerConfigurationResponseCodec";
 
 /**
  * LedgerConfigurationService allows clients to subscribe to changes of
  * the ledger configuration.
  */
-export class LedgerConfigurationClient {
-
-    private readonly request: GetLedgerConfigurationRequest;
-    private readonly client: ILedgerConfigurationServiceClient;
-
-    constructor(ledgerId: string, client: ILedgerConfigurationServiceClient) {
-        this.request = new GetLedgerConfigurationRequest();
-        this.request.setLedgerId(ledgerId);
-        this.client = client;
-    }
+export interface LedgerConfigurationClient {
 
     /**
      * GetLedgerConfiguration returns the latest configuration as the first response, and publishes configuration updates in the same stream.
      */
-    getLedgerConfiguration(): ClientReadableObjectStream<GetLedgerConfigurationResponse> {
-        return ClientReadableObjectStream.from(this.client.getLedgerConfiguration(this.request), GetLedgerConfigurationResponseCodec);
-    }
+    getLedgerConfiguration(): ClientReadableObjectStream<GetLedgerConfigurationResponse>
 
 }

--- a/src/client/LedgerIdentityClient.ts
+++ b/src/client/LedgerIdentityClient.ts
@@ -1,12 +1,9 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ILedgerIdentityServiceClient} from "../generated/com/digitalasset/ledger/api/v1/ledger_identity_service_grpc_pb";
-import {Callback, forward} from "../util/Callback";
+import {Callback} from "../util/Callback";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
 import {GetLedgerIdentityResponse} from "../model/GetLedgerIdentityResponse";
-import {GetLedgerIdentityResponseCodec} from "../codec/GetLedgerIdentityResponseCodec";
-import {GetLedgerIdentityRequest} from "../generated/com/digitalasset/ledger/api/v1/ledger_identity_service_pb";
 
 /**
  * Allows clients to verify that the server they are communicating with
@@ -14,24 +11,13 @@ import {GetLedgerIdentityRequest} from "../generated/com/digitalasset/ledger/api
  *
  * Note that every ledger has a unique id.
  */
-export class LedgerIdentityClient {
-
-    private static request = new GetLedgerIdentityRequest();
-
-    private readonly client: ILedgerIdentityServiceClient;
-
-    constructor(client: ILedgerIdentityServiceClient) {
-        this.client = client;
-    }
+export interface LedgerIdentityClient {
 
     /**
      * Clients may call this RPC to return the identifier of the ledger they
      * are connected to.
      */
-    getLedgerIdentity(callback: Callback<GetLedgerIdentityResponse>): ClientCancellableCall {
-        return ClientCancellableCall.accept(this.client.getLedgerIdentity(LedgerIdentityClient.request, (error, response) => {
-            forward(callback, error, response, GetLedgerIdentityResponseCodec.deserialize);
-        }));
-    }
+    getLedgerIdentity(): Promise<GetLedgerIdentityResponse>
+    getLedgerIdentity(callback: Callback<GetLedgerIdentityResponse>): ClientCancellableCall
 
 }

--- a/src/client/NodeJsActiveContractsClient.ts
+++ b/src/client/NodeJsActiveContractsClient.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {IActiveContractsServiceClient} from '../generated/com/digitalasset/ledger/api/v1/active_contracts_service_grpc_pb';
+import {GetActiveContractsRequest} from "../model/GetActiveContractsRequest";
+import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
+import {GetActiveContractsResponse} from "../model/GetActiveContractsResponse";
+import {GetActiveContractsRequestValidation} from "../validation/GetActiveContractsRequestValidation";
+import {isValid} from "../validation/Validation";
+import {GetActiveContractsResponseCodec} from "../codec/GetActiveContractsResponseCodec";
+import {GetActiveContractsRequestCodec} from "../codec/GetActiveContractsRequestCodec";
+import {ValidationReporter} from "../reporting/ValidationReporter";
+import {ActiveContractsClient} from "./ActiveContractsClient";
+
+export class NodeJsActiveContractsClient implements ActiveContractsClient {
+
+    private readonly ledgerId: string;
+    private readonly client: IActiveContractsServiceClient;
+    private readonly reporter: ValidationReporter;
+
+    constructor(ledgerId: string, client: IActiveContractsServiceClient, reporter: ValidationReporter) {
+        this.ledgerId = ledgerId;
+        this.client = client;
+        this.reporter = reporter;
+    }
+
+    getActiveContracts(requestObject: GetActiveContractsRequest): ClientReadableObjectStream<GetActiveContractsResponse> {
+        const tree = GetActiveContractsRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = GetActiveContractsRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            if (requestObject.verbose === undefined) {
+                request.setVerbose(true);
+            }
+            return ClientReadableObjectStream.from(this.client.getActiveContracts(request), GetActiveContractsResponseCodec);
+        } else {
+            return ClientReadableObjectStream.from(new Error(this.reporter.render(tree)));
+        }
+    }
+
+}

--- a/src/client/NodeJsCommandClient.ts
+++ b/src/client/NodeJsCommandClient.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {Callback, forward, justForward, promisify} from "../util/Callback";
+import {ClientCancellableCall} from "../call/ClientCancellableCall";
+import {ICommandServiceClient} from "../generated/com/digitalasset/ledger/api/v1/command_service_grpc_pb";
+import {ValidationReporter} from "../reporting/ValidationReporter";
+import {SubmitAndWaitRequest} from "../model/SubmitAndWaitRequest";
+import {SubmitAndWaitRequestValidation} from "../validation/SubmitAndWaitRequestValidation";
+import {isValid} from "../validation/Validation";
+import {SubmitAndWaitRequestCodec} from "../codec/SubmitAndWaitRequestCodec";
+import {SubmitAndWaitForTransactionResponse} from "../model/SubmitAndWaitForTransactionResponse";
+import {SubmitAndWaitForTransactionResponseCodec} from "../codec/SubmitAndWaitForTransactionResponseCodec";
+import {SubmitAndWaitForTransactionIdResponse} from "../model/SubmitAndWaitForTransactionIdResponse";
+import {SubmitAndWaitForTransactionIdResponseCodec} from "../codec/SubmitAndWaitForTransactionIdResponseCodec";
+import {SubmitAndWaitForTransactionTreeResponse} from "../model/SubmitAndWaitForTransactionTreeResponse";
+import {SubmitAndWaitForTransactionTreeResponseCodec} from "../codec/SubmitAndWaitForTransactionTreeResponseCodec";
+import {CommandClient} from "./CommandClient";
+
+export class NodeJsCommandClient implements CommandClient {
+
+    private readonly ledgerId: string;
+    private readonly client: ICommandServiceClient;
+    private readonly reporter: ValidationReporter;
+
+    constructor(ledgerId: string, client: ICommandServiceClient, reporter: ValidationReporter) {
+        this.ledgerId = ledgerId;
+        this.client = client;
+        this.reporter = reporter;
+    }
+
+    private submitAndWaitCallback(requestObject: SubmitAndWaitRequest, callback: Callback<null>) {
+        const tree = SubmitAndWaitRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = SubmitAndWaitRequestCodec.serialize(requestObject);
+            request.getCommands()!.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.submitAndWait(request, (error, _) => {
+                justForward(callback, error, null)
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+    };
+
+    private submitAndWaitPromise: (requestObject: SubmitAndWaitRequest) => Promise<null> = promisify(this.submitAndWaitCallback);
+
+    submitAndWait(requestObject: SubmitAndWaitRequest): Promise<null>
+    submitAndWait(requestObject: SubmitAndWaitRequest, callback: Callback<null>): ClientCancellableCall
+    submitAndWait(requestObject: SubmitAndWaitRequest, callback?: Callback<null>): ClientCancellableCall | Promise<null> {
+        return callback ? this.submitAndWaitCallback(requestObject, callback) : this.submitAndWaitPromise(requestObject);
+    }
+
+    private submitAndWaitForTransactionCallback(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionResponse>): ClientCancellableCall {
+        const tree = SubmitAndWaitRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = SubmitAndWaitRequestCodec.serialize(requestObject);
+            request.getCommands()!.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.submitAndWaitForTransaction(request, (error, response) => {
+                forward(callback, error, response, SubmitAndWaitForTransactionResponseCodec.deserialize);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+
+    }
+
+    private submitAndWaitForTransactionPromise: (requestObject: SubmitAndWaitRequest) => Promise<SubmitAndWaitForTransactionResponse> = promisify(this.submitAndWaitForTransactionCallback);
+
+    submitAndWaitForTransaction(requestObject: SubmitAndWaitRequest): Promise<SubmitAndWaitForTransactionResponse>
+    submitAndWaitForTransaction(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionResponse>): ClientCancellableCall
+    submitAndWaitForTransaction(requestObject: SubmitAndWaitRequest, callback?: Callback<SubmitAndWaitForTransactionResponse>): ClientCancellableCall | Promise<SubmitAndWaitForTransactionResponse> {
+        return callback ? this.submitAndWaitForTransactionCallback(requestObject, callback) : this.submitAndWaitForTransactionPromise(requestObject);
+    }
+
+    private submitAndWaitForTransactionIdCallback(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionIdResponse>): ClientCancellableCall {
+        const tree = SubmitAndWaitRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = SubmitAndWaitRequestCodec.serialize(requestObject);
+            request.getCommands()!.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.submitAndWaitForTransactionId(request, (error, response) => {
+                forward(callback, error, response, SubmitAndWaitForTransactionIdResponseCodec.deserialize);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+    }
+
+    private submitAndWaitForTransactionIdPromise: (requestObject: SubmitAndWaitRequest) => Promise<SubmitAndWaitForTransactionIdResponse> = promisify(this.submitAndWaitForTransactionIdCallback);
+
+    submitAndWaitForTransactionId(requestObject: SubmitAndWaitRequest): Promise<SubmitAndWaitForTransactionIdResponse>
+    submitAndWaitForTransactionId(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionIdResponse>): ClientCancellableCall
+    submitAndWaitForTransactionId(requestObject: SubmitAndWaitRequest, callback?: Callback<SubmitAndWaitForTransactionIdResponse>): ClientCancellableCall | Promise<SubmitAndWaitForTransactionIdResponse> {
+        return callback ? this.submitAndWaitForTransactionIdCallback(requestObject, callback) : this.submitAndWaitForTransactionIdPromise(requestObject);
+    }
+
+    private submitAndWaitForTransactionTreeCallback(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionTreeResponse>): ClientCancellableCall {
+        const tree = SubmitAndWaitRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = SubmitAndWaitRequestCodec.serialize(requestObject);
+            request.getCommands()!.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.submitAndWaitForTransactionTree(request, (error, response) => {
+                forward(callback, error, response, SubmitAndWaitForTransactionTreeResponseCodec.deserialize);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+    }
+
+    private submitAndWaitForTransactionTreePromise: (requestObject: SubmitAndWaitRequest) => Promise<SubmitAndWaitForTransactionTreeResponse> = promisify(this.submitAndWaitForTransactionTreeCallback);
+
+    submitAndWaitForTransactionTree(requestObject: SubmitAndWaitRequest): Promise<SubmitAndWaitForTransactionTreeResponse>
+    submitAndWaitForTransactionTree(requestObject: SubmitAndWaitRequest, callback: Callback<SubmitAndWaitForTransactionTreeResponse>): ClientCancellableCall
+    submitAndWaitForTransactionTree(requestObject: SubmitAndWaitRequest, callback?: Callback<SubmitAndWaitForTransactionTreeResponse>): ClientCancellableCall | Promise<SubmitAndWaitForTransactionTreeResponse> {
+        return callback ? this.submitAndWaitForTransactionTreeCallback(requestObject, callback) : this.submitAndWaitForTransactionTreePromise(requestObject);
+    }
+
+}

--- a/src/client/NodeJsCommandCompletionClient.ts
+++ b/src/client/NodeJsCommandCompletionClient.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {ICommandCompletionServiceClient} from "../generated/com/digitalasset/ledger/api/v1/command_completion_service_grpc_pb";
+import {ValidationReporter} from "../reporting/ValidationReporter";
+import {CompletionEndRequest} from "../generated/com/digitalasset/ledger/api/v1/command_completion_service_pb";
+import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
+import {CompletionStreamResponse} from "../model/CompletionStreamResponse";
+import {CompletionStreamRequestValidation} from "../validation/CompletionStreamRequestValidation";
+import {Callback, forward, promisify} from "../util/Callback";
+import {ClientCancellableCall} from "../call/ClientCancellableCall";
+import {CompletionEndResponseCodec} from "../codec/CompletionEndResponseCodec";
+import {CompletionEndResponse} from "../model/CompletionEndResponse";
+import {CompletionStreamResponseCodec} from "../codec/CompletionStreamResponseCodec";
+import {isValid} from "../validation/Validation";
+import {CompletionStreamRequestCodec} from "../codec/CompletionStreamRequestCodec";
+import {CompletionStreamRequest} from "../model/CompletionStreamRequest";
+import {CommandCompletionClient} from "./CommandCompletionClient";
+
+export class NodeJsCommandCompletionClient implements CommandCompletionClient {
+
+    private readonly completionEndRequest: CompletionEndRequest;
+    private readonly client: ICommandCompletionServiceClient;
+    private readonly ledgerId: string;
+    private readonly reporter: ValidationReporter
+
+    constructor(ledgerId: string, client: ICommandCompletionServiceClient, reporter: ValidationReporter) {
+        this.completionEndRequest = new CompletionEndRequest();
+        this.completionEndRequest.setLedgerId(ledgerId);
+        this.ledgerId = ledgerId;
+        this.client = client;
+        this.reporter = reporter;
+    }
+
+    completionStream(requestObject: CompletionStreamRequest): ClientReadableObjectStream<CompletionStreamResponse> {
+        const tree = CompletionStreamRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = CompletionStreamRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            return ClientReadableObjectStream.from(this.client.completionStream(request), CompletionStreamResponseCodec);
+        } else {
+            return ClientReadableObjectStream.from(new Error(this.reporter.render(tree)));
+        }
+    }
+
+    private completionEndCallback(callback: Callback<CompletionEndResponse>): ClientCancellableCall {
+        return ClientCancellableCall.accept(this.client.completionEnd(this.completionEndRequest, (error, response) => {
+            forward(callback, error, response, CompletionEndResponseCodec.deserialize);
+        }));
+    }
+
+    private completionEndPromise: () => Promise<CompletionEndResponse> = promisify(this.completionEndCallback)
+
+    completionEnd(): Promise<CompletionEndResponse>
+    completionEnd(callback: Callback<CompletionEndResponse>): ClientCancellableCall
+    completionEnd(callback?: Callback<CompletionEndResponse>): ClientCancellableCall | Promise<CompletionEndResponse> {
+        return callback ? this.completionEndCallback(callback) : this.completionEndPromise();
+    }
+
+}

--- a/src/client/NodeJsCommandSubmissionClient.ts
+++ b/src/client/NodeJsCommandSubmissionClient.ts
@@ -3,7 +3,7 @@
 
 import {SubmitRequestValidation} from "../validation/SubmitRequestValidation";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
-import {Callback, justForward, promisify} from "../util/Callback";
+import {Callback, forwardVoidResponse, promisify} from "../util/Callback";
 import {ValidationReporter} from "../reporting/ValidationReporter";
 import {ICommandSubmissionServiceClient} from "../generated/com/digitalasset/ledger/api/v1/command_submission_service_grpc_pb";
 import {SubmitRequest} from "../model/SubmitRequest";
@@ -23,7 +23,7 @@ export class NodeJsCommandSubmissionClient implements CommandSubmissionClient {
         this.reporter = reporter;
     }
 
-    private submitCallback(requestObject: SubmitRequest, callback: Callback<null>): ClientCancellableCall {
+    private submitCallback(requestObject: SubmitRequest, callback: Callback<void>): ClientCancellableCall {
         const tree = SubmitRequestValidation.validate(requestObject);
         if (isValid(tree)) {
             const request = SubmitRequestCodec.serialize(requestObject);
@@ -31,7 +31,7 @@ export class NodeJsCommandSubmissionClient implements CommandSubmissionClient {
                 request.getCommands()!.setLedgerId(this.ledgerId);
             }
             return ClientCancellableCall.accept(this.client.submit(request, (error, _) => {
-                justForward(callback, error, null);
+                forwardVoidResponse(callback, error);
             }));
         } else {
             setImmediate(() => callback(new Error(this.reporter.render(tree))));
@@ -39,11 +39,11 @@ export class NodeJsCommandSubmissionClient implements CommandSubmissionClient {
         }
     }
 
-    private submitPromise: (requestObject: SubmitRequest) => Promise<null> = promisify(this.submitCallback)
+    private submitPromise: (requestObject: SubmitRequest) => Promise<void> = promisify(this.submitCallback)
 
-    submit(requestObject: SubmitRequest): Promise<null>
-    submit(requestObject: SubmitRequest, callback: Callback<null>): ClientCancellableCall
-    submit(requestObject: SubmitRequest, callback?: Callback<null>): ClientCancellableCall | Promise<null> {
+    submit(requestObject: SubmitRequest): Promise<void>
+    submit(requestObject: SubmitRequest, callback: Callback<void>): ClientCancellableCall
+    submit(requestObject: SubmitRequest, callback?: Callback<void>): ClientCancellableCall | Promise<void> {
         return callback ? this.submitCallback(requestObject, callback) : this.submitPromise(requestObject);
     }
 

--- a/src/client/NodeJsCommandSubmissionClient.ts
+++ b/src/client/NodeJsCommandSubmissionClient.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {SubmitRequestValidation} from "../validation/SubmitRequestValidation";
+import {ClientCancellableCall} from "../call/ClientCancellableCall";
+import {Callback, justForward, promisify} from "../util/Callback";
+import {ValidationReporter} from "../reporting/ValidationReporter";
+import {ICommandSubmissionServiceClient} from "../generated/com/digitalasset/ledger/api/v1/command_submission_service_grpc_pb";
+import {SubmitRequest} from "../model/SubmitRequest";
+import {isValid} from "../validation/Validation";
+import {SubmitRequestCodec} from "../codec/SubmitRequestCodec";
+import {CommandSubmissionClient} from "./CommandSubmissionClient";
+
+export class NodeJsCommandSubmissionClient implements CommandSubmissionClient {
+
+    private readonly ledgerId: string;
+    private readonly client: ICommandSubmissionServiceClient;
+    private readonly reporter: ValidationReporter;
+
+    constructor(ledgerId: string, client: ICommandSubmissionServiceClient, reporter: ValidationReporter) {
+        this.ledgerId = ledgerId;
+        this.client = client;
+        this.reporter = reporter;
+    }
+
+    private submitCallback(requestObject: SubmitRequest, callback: Callback<null>): ClientCancellableCall {
+        const tree = SubmitRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = SubmitRequestCodec.serialize(requestObject);
+            if (request.hasCommands()) {
+                request.getCommands()!.setLedgerId(this.ledgerId);
+            }
+            return ClientCancellableCall.accept(this.client.submit(request, (error, _) => {
+                justForward(callback, error, null);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+    }
+
+    private submitPromise: (requestObject: SubmitRequest) => Promise<null> = promisify(this.submitCallback)
+
+    submit(requestObject: SubmitRequest): Promise<null>
+    submit(requestObject: SubmitRequest, callback: Callback<null>): ClientCancellableCall
+    submit(requestObject: SubmitRequest, callback?: Callback<null>): ClientCancellableCall | Promise<null> {
+        return callback ? this.submitCallback(requestObject, callback) : this.submitPromise(requestObject);
+    }
+
+}

--- a/src/client/NodeJsLedgerConfigurationClient.ts
+++ b/src/client/NodeJsLedgerConfigurationClient.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetLedgerConfigurationRequest} from "../generated/com/digitalasset/ledger/api/v1/ledger_configuration_service_pb";
+import {ILedgerConfigurationServiceClient} from "../generated/com/digitalasset/ledger/api/v1/ledger_configuration_service_grpc_pb";
+import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
+import {GetLedgerConfigurationResponse} from "../model/GetLedgerConfigurationResponse";
+import {GetLedgerConfigurationResponseCodec} from "../codec/GetLedgerConfigurationResponseCodec";
+import {LedgerConfigurationClient} from "./LedgerConfigurationClient";
+
+export class NodeJsLedgerConfigurationClient implements LedgerConfigurationClient {
+
+    private readonly request: GetLedgerConfigurationRequest;
+    private readonly client: ILedgerConfigurationServiceClient;
+
+    constructor(ledgerId: string, client: ILedgerConfigurationServiceClient) {
+        this.request = new GetLedgerConfigurationRequest();
+        this.request.setLedgerId(ledgerId);
+        this.client = client;
+    }
+
+    getLedgerConfiguration(): ClientReadableObjectStream<GetLedgerConfigurationResponse> {
+        return ClientReadableObjectStream.from(this.client.getLedgerConfiguration(this.request), GetLedgerConfigurationResponseCodec);
+    }
+
+}

--- a/src/client/NodeJsLedgerIdentityClient.ts
+++ b/src/client/NodeJsLedgerIdentityClient.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {ILedgerIdentityServiceClient} from "../generated/com/digitalasset/ledger/api/v1/ledger_identity_service_grpc_pb";
+import {Callback, forward, promisify} from "../util/Callback";
+import {ClientCancellableCall} from "../call/ClientCancellableCall";
+import {GetLedgerIdentityResponse} from "../model/GetLedgerIdentityResponse";
+import {GetLedgerIdentityResponseCodec} from "../codec/GetLedgerIdentityResponseCodec";
+import {GetLedgerIdentityRequest} from "../generated/com/digitalasset/ledger/api/v1/ledger_identity_service_pb";
+
+export class NodeJsLedgerIdentityClient {
+
+    private static request = new GetLedgerIdentityRequest();
+
+    private readonly client: ILedgerIdentityServiceClient;
+
+    constructor(client: ILedgerIdentityServiceClient) {
+        this.client = client;
+    }
+
+    private getLedgerIdentityCallback(callback: Callback<GetLedgerIdentityResponse>): ClientCancellableCall {
+        return ClientCancellableCall.accept(this.client.getLedgerIdentity(NodeJsLedgerIdentityClient.request, (error, response) => {
+            forward(callback, error, response, GetLedgerIdentityResponseCodec.deserialize);
+        }));
+    }
+
+    private getLedgerIdentityPromise: () => Promise<GetLedgerIdentityResponse> = promisify(this.getLedgerIdentityCallback);
+
+    getLedgerIdentity(): Promise<GetLedgerIdentityResponse>
+    getLedgerIdentity(callback: Callback<GetLedgerIdentityResponse>): ClientCancellableCall
+    getLedgerIdentity(callback?: Callback<GetLedgerIdentityResponse>): ClientCancellableCall | Promise<GetLedgerIdentityResponse> {
+        return callback ? this.getLedgerIdentityCallback(callback) : this.getLedgerIdentityPromise();
+    }
+
+}

--- a/src/client/NodeJsPackageClient.ts
+++ b/src/client/NodeJsPackageClient.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {IPackageServiceClient} from "../generated/com/digitalasset/ledger/api/v1/package_service_grpc_pb";
+import {
+    GetPackageRequest,
+    GetPackageStatusRequest,
+    ListPackagesRequest
+} from "../generated/com/digitalasset/ledger/api/v1/package_service_pb";
+import {Callback, forward, promisify} from "../util/Callback";
+import {ClientCancellableCall} from "../call/ClientCancellableCall";
+import {ListPackagesResponseCodec} from "../codec/ListPackagesResponseCodec";
+import {ListPackagesResponse} from "../model/ListPackagesResponse";
+import {GetPackageResponse} from "../model/GetPackageResponse";
+import {GetPackageResponseCodec} from "../codec/GetPackageResponseCodec";
+import {GetPackageStatusResponse} from "../model/GetPackageStatusResponse";
+import {GetPackageStatusResponseCodec} from "../codec/GetPackageStatusResponseCodec";
+
+export class NodeJsPackageClient {
+
+    private readonly ledgerId: string;
+    private readonly listPackagesRequest: ListPackagesRequest;
+    private readonly client: IPackageServiceClient;
+
+    constructor(ledgerId: string, client: IPackageServiceClient) {
+        this.client = client;
+        this.ledgerId = ledgerId;
+        this.listPackagesRequest = new ListPackagesRequest();
+        this.listPackagesRequest.setLedgerId(this.ledgerId);
+    }
+
+    private listPackagesCallback(callback: Callback<ListPackagesResponse>): ClientCancellableCall {
+        return ClientCancellableCall.accept(this.client.listPackages(this.listPackagesRequest, (error, response) => {
+            forward(callback, error, response, ListPackagesResponseCodec.deserialize);
+        }));
+    }
+
+    private listPackagesPromise: () => Promise<ListPackagesResponse> = promisify(this.listPackagesCallback);
+
+    listPackages(): Promise<ListPackagesResponse>
+    listPackages(callback: Callback<ListPackagesResponse>): ClientCancellableCall
+    listPackages(callback?: Callback<ListPackagesResponse>): ClientCancellableCall | Promise<ListPackagesResponse> {
+        return callback ? this.listPackagesCallback(callback) : this.listPackagesPromise();
+    }
+
+    private getPackageCallback(packageId: string, callback: Callback<GetPackageResponse>): ClientCancellableCall {
+        const request = new GetPackageRequest();
+        request.setLedgerId(this.ledgerId);
+        request.setPackageId(packageId);
+        return ClientCancellableCall.accept(this.client.getPackage(request, (error, response) => {
+            forward(callback, error, response, GetPackageResponseCodec.deserialize);
+        }));
+    }
+
+    private getPackagePromise: (packageId: string) => Promise<GetPackageResponse> = promisify(this.getPackageCallback);
+
+    getPackage(packageId: string): Promise<GetPackageResponse>
+    getPackage(packageId: string, callback: Callback<GetPackageResponse>): ClientCancellableCall
+    getPackage(packageId: string, callback?: Callback<GetPackageResponse>): ClientCancellableCall | Promise<GetPackageResponse> {
+        return callback ? this.getPackageCallback(packageId, callback) : this.getPackagePromise(packageId);
+    }
+
+    private getPackageStatusCallback(packageId: string, callback: Callback<GetPackageStatusResponse>): ClientCancellableCall {
+        const request = new GetPackageStatusRequest();
+        request.setLedgerId(this.ledgerId);
+        request.setPackageId(packageId);
+        return ClientCancellableCall.accept(this.client.getPackageStatus(request, (error, response) => {
+            forward(callback, error, response, GetPackageStatusResponseCodec.deserialize);
+        }));
+    }
+
+    private getPackageStatusPromise: (packageId: string) => Promise<GetPackageStatusResponse> = promisify(this.getPackageStatusCallback);
+
+    getPackageStatus(packageId: string): Promise<GetPackageStatusResponse>
+    getPackageStatus(packageId: string, callback: Callback<GetPackageStatusResponse>): ClientCancellableCall
+    getPackageStatus(packageId: string, callback?: Callback<GetPackageStatusResponse>): ClientCancellableCall | Promise<GetPackageStatusResponse> {
+        return callback ? this.getPackageStatusCallback(packageId, callback) : this.getPackageStatusPromise(packageId);
+    }
+
+}

--- a/src/client/NodeJsResetClient.ts
+++ b/src/client/NodeJsResetClient.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {ResetRequest} from "../generated/com/digitalasset/ledger/api/v1/testing/reset_service_pb";
+import {Callback, justForward, promisify} from "../util/Callback";
+import {ClientCancellableCall} from "../call/ClientCancellableCall";
+import {IResetServiceClient} from "../generated/com/digitalasset/ledger/api/v1/testing/reset_service_grpc_pb";
+
+export class NodeJsResetClient {
+
+    private readonly request: ResetRequest;
+    private readonly client: IResetServiceClient;
+
+    constructor(ledgerId: string, client: IResetServiceClient) {
+        this.client = client;
+        this.request = new ResetRequest();
+        this.request.setLedgerId(ledgerId);
+    }
+
+    private resetCallback(callback: Callback<null>) {
+        return ClientCancellableCall.accept(this.client.reset(this.request, (error, _) => {
+            justForward(callback, error, null)
+        }));
+    }
+
+    private resetPromise: () => Promise<null> = promisify(this.resetCallback);
+
+    reset(): Promise<null>
+    reset(callback: Callback<null>): ClientCancellableCall
+    reset(callback?: Callback<null>): ClientCancellableCall | Promise<null> {
+        return callback ? this.resetCallback(callback) : this.resetPromise();
+    }
+
+}

--- a/src/client/NodeJsResetClient.ts
+++ b/src/client/NodeJsResetClient.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {ResetRequest} from "../generated/com/digitalasset/ledger/api/v1/testing/reset_service_pb";
-import {Callback, justForward, promisify} from "../util/Callback";
+import {Callback, forwardVoidResponse, promisify} from "../util/Callback";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
 import {IResetServiceClient} from "../generated/com/digitalasset/ledger/api/v1/testing/reset_service_grpc_pb";
 
@@ -17,17 +17,17 @@ export class NodeJsResetClient {
         this.request.setLedgerId(ledgerId);
     }
 
-    private resetCallback(callback: Callback<null>) {
+    private resetCallback(callback: Callback<void>) {
         return ClientCancellableCall.accept(this.client.reset(this.request, (error, _) => {
-            justForward(callback, error, null)
+            forwardVoidResponse(callback, error);
         }));
     }
 
-    private resetPromise: () => Promise<null> = promisify(this.resetCallback);
+    private resetPromise: () => Promise<void> = promisify(this.resetCallback);
 
-    reset(): Promise<null>
-    reset(callback: Callback<null>): ClientCancellableCall
-    reset(callback?: Callback<null>): ClientCancellableCall | Promise<null> {
+    reset(): Promise<void>
+    reset(callback: Callback<void>): ClientCancellableCall
+    reset(callback?: Callback<void>): ClientCancellableCall | Promise<void> {
         return callback ? this.resetCallback(callback) : this.resetPromise();
     }
 

--- a/src/client/NodeJsTimeClient.ts
+++ b/src/client/NodeJsTimeClient.ts
@@ -3,7 +3,7 @@
 
 import {SetTimeRequestValidation} from "../validation/SetTimeRequestValidation";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
-import {Callback, justForward, promisify} from "../util/Callback";
+import {Callback, forwardVoidResponse, promisify} from "../util/Callback";
 import {SetTimeRequest} from "../model/SetTimeRequest";
 import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
 import {GetTimeResponse} from "../model/GetTimeResponse";
@@ -33,13 +33,13 @@ export class NodeJsTimeClient {
         return ClientReadableObjectStream.from(this.client.getTime(this.request), GetTimeResponseCodec);
     }
 
-    private setTimeCallback(requestObject: SetTimeRequest, callback: Callback<null>): ClientCancellableCall {
+    private setTimeCallback(requestObject: SetTimeRequest, callback: Callback<void>): ClientCancellableCall {
         const tree = SetTimeRequestValidation.validate(requestObject);
         if (isValid(tree)) {
             const request = SetTimeRequestCodec.serialize(requestObject);
             request.setLedgerId(this.ledgerId);
             return ClientCancellableCall.accept(this.client.setTime(request, (error, _) => {
-                justForward(callback, error, null)
+                forwardVoidResponse(callback, error);
             }));
         } else {
             setImmediate(() => {
@@ -49,11 +49,11 @@ export class NodeJsTimeClient {
         }
     }
 
-    private setTimePromise: (requestObject: SetTimeRequest) => Promise<null> = promisify(this.setTimeCallback);
+    private setTimePromise: (requestObject: SetTimeRequest) => Promise<void> = promisify(this.setTimeCallback);
 
-    setTime(requestObject: SetTimeRequest): Promise<null>
-    setTime(requestObject: SetTimeRequest, callback: Callback<null>): ClientCancellableCall
-    setTime(requestObject: SetTimeRequest, callback?: Callback<null>): ClientCancellableCall | Promise<null> {
+    setTime(requestObject: SetTimeRequest): Promise<void>
+    setTime(requestObject: SetTimeRequest, callback: Callback<void>): ClientCancellableCall
+    setTime(requestObject: SetTimeRequest, callback?: Callback<void>): ClientCancellableCall | Promise<void> {
         return callback ? this.setTimeCallback(requestObject, callback) : this.setTimePromise(requestObject);
     }
 

--- a/src/client/NodeJsTimeClient.ts
+++ b/src/client/NodeJsTimeClient.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {SetTimeRequestValidation} from "../validation/SetTimeRequestValidation";
+import {ClientCancellableCall} from "../call/ClientCancellableCall";
+import {Callback, justForward, promisify} from "../util/Callback";
+import {SetTimeRequest} from "../model/SetTimeRequest";
+import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
+import {GetTimeResponse} from "../model/GetTimeResponse";
+import {isValid} from "../validation/Validation";
+import {GetTimeResponseCodec} from "../codec/GetTimeResponseCodec";
+import {SetTimeRequestCodec} from "../codec/SetTimeRequestCodec";
+import {GetTimeRequest} from "../generated/com/digitalasset/ledger/api/v1/testing/time_service_pb";
+import {ITimeServiceClient} from "../generated/com/digitalasset/ledger/api/v1/testing/time_service_grpc_pb";
+import {ValidationReporter} from "../reporting/ValidationReporter";
+
+export class NodeJsTimeClient {
+
+    private readonly ledgerId: string;
+    private readonly request: GetTimeRequest;
+    private readonly client: ITimeServiceClient;
+    private readonly reporter: ValidationReporter;
+
+    constructor(ledgerId: string, client: ITimeServiceClient, reporter: ValidationReporter) {
+        this.ledgerId = ledgerId;
+        this.request = new GetTimeRequest();
+        this.request.setLedgerId(this.ledgerId);
+        this.client = client;
+        this.reporter = reporter;
+    }
+
+    getTime(): ClientReadableObjectStream<GetTimeResponse> {
+        return ClientReadableObjectStream.from(this.client.getTime(this.request), GetTimeResponseCodec);
+    }
+
+    private setTimeCallback(requestObject: SetTimeRequest, callback: Callback<null>): ClientCancellableCall {
+        const tree = SetTimeRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = SetTimeRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.setTime(request, (error, _) => {
+                justForward(callback, error, null)
+            }));
+        } else {
+            setImmediate(() => {
+                callback(new Error(this.reporter.render(tree)));
+            });
+            return ClientCancellableCall.rejected;
+        }
+    }
+
+    private setTimePromise: (requestObject: SetTimeRequest) => Promise<null> = promisify(this.setTimeCallback);
+
+    setTime(requestObject: SetTimeRequest): Promise<null>
+    setTime(requestObject: SetTimeRequest, callback: Callback<null>): ClientCancellableCall
+    setTime(requestObject: SetTimeRequest, callback?: Callback<null>): ClientCancellableCall | Promise<null> {
+        return callback ? this.setTimeCallback(requestObject, callback) : this.setTimePromise(requestObject);
+    }
+
+}

--- a/src/client/NodeJsTransactionClient.ts
+++ b/src/client/NodeJsTransactionClient.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {ITransactionServiceClient} from "../generated/com/digitalasset/ledger/api/v1/transaction_service_grpc_pb";
+import {ValidationReporter} from "../reporting/ValidationReporter";
+import {ClientCancellableCall} from "../call/ClientCancellableCall";
+import {GetLedgerEndRequest} from "../generated/com/digitalasset/ledger/api/v1/transaction_service_pb";
+import {GetLedgerEndResponse} from "../model/GetLedgerEndResponse";
+import {Callback, forward, promisify} from "../util/Callback";
+import {GetLedgerEndResponseCodec} from "../codec/GetLedgerEndResponseCodec";
+import {GetTransactionResponse} from "../model/GetTransactionResponse";
+import {GetTransactionByEventIdRequest} from "../model/GetTransactionByEventIdRequest";
+import {GetTransactionByEventIdRequestValidation} from "../validation/GetTransactionByEventIdRequestValidation";
+import {isValid} from "../validation/Validation";
+import {GetTransactionByEventIdRequestCodec} from "../codec/GetTransactionByEventIdRequestCodec";
+import {GetTransactionResponseCodec} from "../codec/GetTransactionResponseCodec";
+import {GetTransactionByIdRequestCodec} from "../codec/GetTransactionByIdRequestCodec";
+import {GetTransactionByIdRequest} from "../model/GetTransactionByIdRequest";
+import {GetTransactionsRequestValidation} from "../validation/GetTransactionsRequestValidation";
+import {GetTransactionsResponse} from "../model/GetTransactionsResponse";
+import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
+import {GetTransactionsRequest} from "../model/GetTransactionsRequest";
+import {GetTransactionsRequestCodec} from "../codec/GetTransactionsRequestCodec";
+import {GetTransactionsResponseCodec} from "../codec/GetTransactionsResponseCodec";
+import {GetTransactionTreesResponse} from "../model/GetTransactionTreesResponse";
+import {GetTransactionTreesResponseCodec} from "../codec/GetTransactionTreesResponseCodec";
+import {GetFlatTransactionResponse} from "../model/GetFlatTransactionResponse";
+import {GetFlatTransactionResponseCodec} from "../codec/GetFlatTransactionResponseCodec";
+import {GetTransactionByIdRequestValidation} from "../validation/GetTransactionByIdRequestValidation";
+
+export class NodeJsTransactionClient {
+
+    private readonly ledgerId: string;
+    private readonly client: ITransactionServiceClient;
+    private readonly reporter: ValidationReporter;
+
+    constructor(ledgerId: string, client: ITransactionServiceClient, reporter: ValidationReporter) {
+        this.ledgerId = ledgerId;
+        this.client = client;
+        this.reporter = reporter;
+    }
+
+    private getLedgerEndCallback(callback: Callback<GetLedgerEndResponse>): ClientCancellableCall {
+        const request = new GetLedgerEndRequest();
+        request.setLedgerId(this.ledgerId);
+        return ClientCancellableCall.accept(this.client.getLedgerEnd(request, (error, response) => {
+            forward(callback, error, response, GetLedgerEndResponseCodec.deserialize);
+        }));
+    }
+
+    private getLedgerEndPromise: () => Promise<GetLedgerEndResponse> = promisify(this.getLedgerEndCallback);
+
+    getLedgerEnd(): Promise<GetLedgerEndResponse>
+    getLedgerEnd(callback: Callback<GetLedgerEndResponse>): ClientCancellableCall
+    getLedgerEnd(callback?: Callback<GetLedgerEndResponse>): ClientCancellableCall | Promise<GetLedgerEndResponse> {
+        return callback ? this.getLedgerEndCallback(callback) : this.getLedgerEndPromise();
+    }
+
+    private getTransactionByEventIdCallback(requestObject: GetTransactionByEventIdRequest, callback: Callback<GetTransactionResponse>): ClientCancellableCall {
+        const tree = GetTransactionByEventIdRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = GetTransactionByEventIdRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.getTransactionByEventId(request, (error, response) => {
+                forward(callback, error, response, GetTransactionResponseCodec.deserialize);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+    }
+
+    private getTransactionByEventIdPromise: (requestObject: GetTransactionByEventIdRequest) => Promise<GetTransactionResponse> = promisify(this.getTransactionByEventIdCallback);
+
+    getTransactionByEventId(requestObject: GetTransactionByEventIdRequest): Promise<GetTransactionResponse>
+    getTransactionByEventId(requestObject: GetTransactionByEventIdRequest, callback: Callback<GetTransactionResponse>): ClientCancellableCall
+    getTransactionByEventId(requestObject: GetTransactionByEventIdRequest, callback?: Callback<GetTransactionResponse>): ClientCancellableCall | Promise<GetTransactionResponse> {
+        return callback ? this.getTransactionByEventIdCallback(requestObject, callback) : this.getTransactionByEventIdPromise(requestObject);
+    }
+
+    private getFlatTransactionByEventIdCallback(requestObject: GetTransactionByEventIdRequest, callback: Callback<GetFlatTransactionResponse>): ClientCancellableCall {
+        const tree = GetTransactionByEventIdRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = GetTransactionByEventIdRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.getFlatTransactionByEventId(request, (error, response) => {
+                forward(callback, error, response, GetFlatTransactionResponseCodec.deserialize);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+    }
+
+    private getFlatTransactionByEventIdPromise: (requestObject: GetTransactionByEventIdRequest) => Promise<GetFlatTransactionResponse> = promisify(this.getFlatTransactionByEventIdCallback);
+
+    getFlatTransactionByEventId(requestObject: GetTransactionByEventIdRequest): Promise<GetFlatTransactionResponse>
+    getFlatTransactionByEventId(requestObject: GetTransactionByEventIdRequest, callback: Callback<GetFlatTransactionResponse>): ClientCancellableCall
+    getFlatTransactionByEventId(requestObject: GetTransactionByEventIdRequest, callback?: Callback<GetFlatTransactionResponse>): ClientCancellableCall | Promise<GetFlatTransactionResponse> {
+        return callback ? this.getFlatTransactionByEventIdCallback(requestObject, callback) : this.getFlatTransactionByEventIdPromise(requestObject);
+    }
+
+    private getTransactionByIdCallback(requestObject: GetTransactionByIdRequest, callback: Callback<GetTransactionResponse>): ClientCancellableCall {
+        const tree = GetTransactionByIdRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = GetTransactionByIdRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.getTransactionById(request, (error, response) => {
+                forward(callback, error, response, GetTransactionResponseCodec.deserialize);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+    }
+
+    private getTransactionByIdPromise: (requestObject: GetTransactionByIdRequest) => Promise<GetTransactionResponse> = promisify(this.getTransactionByIdCallback);
+
+    getTransactionById(requestObject: GetTransactionByIdRequest): Promise<GetTransactionResponse>
+    getTransactionById(requestObject: GetTransactionByIdRequest, callback: Callback<GetTransactionResponse>): ClientCancellableCall
+    getTransactionById(requestObject: GetTransactionByIdRequest, callback?: Callback<GetTransactionResponse>): ClientCancellableCall | Promise<GetTransactionResponse> {
+        return callback ? this.getTransactionByIdCallback(requestObject, callback) : this.getTransactionByIdPromise(requestObject);
+    }
+
+    private getFlatTransactionByIdCallback(requestObject: GetTransactionByIdRequest, callback: Callback<GetFlatTransactionResponse>): ClientCancellableCall {
+        const tree = GetTransactionByIdRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = GetTransactionByIdRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            return ClientCancellableCall.accept(this.client.getFlatTransactionById(request, (error, response) => {
+                forward(callback, error, response, GetFlatTransactionResponseCodec.deserialize);
+            }));
+        } else {
+            setImmediate(() => callback(new Error(this.reporter.render(tree))));
+            return ClientCancellableCall.rejected;
+        }
+    }
+
+    private getFlatTransactionByIdPromise: (requestObject: GetTransactionByIdRequest) => Promise<GetFlatTransactionResponse> = promisify(this.getFlatTransactionByIdCallback);
+
+    getFlatTransactionById(requestObject: GetTransactionByIdRequest): Promise<GetFlatTransactionResponse>
+    getFlatTransactionById(requestObject: GetTransactionByIdRequest, callback: Callback<GetFlatTransactionResponse>): ClientCancellableCall
+    getFlatTransactionById(requestObject: GetTransactionByIdRequest, callback?: Callback<GetFlatTransactionResponse>): ClientCancellableCall | Promise<GetFlatTransactionResponse> {
+        return callback ? this.getFlatTransactionByIdCallback(requestObject, callback) : this.getFlatTransactionByIdPromise(requestObject);
+    }
+
+    getTransactions(requestObject: GetTransactionsRequest): ClientReadableObjectStream<GetTransactionsResponse> {
+        const tree = GetTransactionsRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = GetTransactionsRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            if (requestObject.verbose === undefined) {
+                request.setVerbose(true);
+            }
+            return ClientReadableObjectStream.from(this.client.getTransactions(request), GetTransactionsResponseCodec);
+        } else {
+            return ClientReadableObjectStream.from(new Error(this.reporter.render(tree)));
+        }
+    }
+
+    getTransactionTrees(requestObject: GetTransactionsRequest): ClientReadableObjectStream<GetTransactionTreesResponse> {
+        const tree = GetTransactionsRequestValidation.validate(requestObject);
+        if (isValid(tree)) {
+            const request = GetTransactionsRequestCodec.serialize(requestObject);
+            request.setLedgerId(this.ledgerId);
+            return ClientReadableObjectStream.from(this.client.getTransactionTrees(request), GetTransactionTreesResponseCodec);
+        } else {
+            return ClientReadableObjectStream.from(new Error(this.reporter.render(tree)));
+        }
+    }
+
+}

--- a/src/client/PackageClient.ts
+++ b/src/client/PackageClient.ts
@@ -1,70 +1,35 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {IPackageServiceClient} from "../generated/com/digitalasset/ledger/api/v1/package_service_grpc_pb";
-import {
-    GetPackageRequest,
-    GetPackageStatusRequest,
-    ListPackagesRequest
-} from "../generated/com/digitalasset/ledger/api/v1/package_service_pb";
-import {Callback, forward} from "../util/Callback";
+import {Callback} from "../util/Callback";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
-import {ListPackagesResponseCodec} from "../codec/ListPackagesResponseCodec";
 import {ListPackagesResponse} from "../model/ListPackagesResponse";
 import {GetPackageResponse} from "../model/GetPackageResponse";
-import {GetPackageResponseCodec} from "../codec/GetPackageResponseCodec";
 import {GetPackageStatusResponse} from "../model/GetPackageStatusResponse";
-import {GetPackageStatusResponseCodec} from "../codec/GetPackageStatusResponseCodec";
 
 /**
  * Allows clients to query the DAML LF packages that are supported by the
  * server.
  */
-export class PackageClient {
-
-    private readonly ledgerId: string;
-    private readonly listPackagesRequest: ListPackagesRequest;
-    private readonly client: IPackageServiceClient;
-
-    constructor(ledgerId: string, client: IPackageServiceClient) {
-        this.client = client;
-        this.ledgerId = ledgerId;
-        this.listPackagesRequest = new ListPackagesRequest();
-        this.listPackagesRequest.setLedgerId(this.ledgerId);
-    }
+export interface PackageClient {
 
     /**
      * Returns the identifiers of all supported packages.
      */
-    listPackages(callback: Callback<ListPackagesResponse>): ClientCancellableCall {
-        return ClientCancellableCall.accept(this.client.listPackages(this.listPackagesRequest, (error, response) => {
-            forward(callback, error, response, ListPackagesResponseCodec.deserialize);
-        }));
-    }
+    listPackages(): Promise<ListPackagesResponse>
+    listPackages(callback: Callback<ListPackagesResponse>): ClientCancellableCall
 
     /**
      * Returns the contents of a single package, or a NOT_FOUND error if the
      * requested package is unknown.
      */
-    getPackage(packageId: string, callback: Callback<GetPackageResponse>): ClientCancellableCall {
-        const request = new GetPackageRequest();
-        request.setLedgerId(this.ledgerId);
-        request.setPackageId(packageId);
-        return ClientCancellableCall.accept(this.client.getPackage(request, (error, response) => {
-            forward(callback, error, response, GetPackageResponseCodec.deserialize);
-        }));
-    }
+    getPackage(packageId: string): Promise<GetPackageResponse>
+    getPackage(packageId: string, callback: Callback<GetPackageResponse>): ClientCancellableCall
 
     /**
      * Returns the status of a single package.
      */
-    getPackageStatus(packageId: string, callback: Callback<GetPackageStatusResponse>): ClientCancellableCall {
-        const request = new GetPackageStatusRequest();
-        request.setLedgerId(this.ledgerId);
-        request.setPackageId(packageId);
-        return ClientCancellableCall.accept(this.client.getPackageStatus(request, (error, response) => {
-            forward(callback, error, response, GetPackageStatusResponseCodec.deserialize);
-        }));
-    }
+    getPackageStatus(packageId: string): Promise<GetPackageStatusResponse>
+    getPackageStatus(packageId: string, callback: Callback<GetPackageStatusResponse>): ClientCancellableCall
 
 }

--- a/src/client/ResetClient.ts
+++ b/src/client/ResetClient.ts
@@ -6,7 +6,7 @@ import {ClientCancellableCall} from "../call/ClientCancellableCall";
 
 export interface ResetClient {
 
-    reset(): Promise<null>
-    reset(callback: Callback<null>): ClientCancellableCall
+    reset(): Promise<void>
+    reset(callback: Callback<void>): ClientCancellableCall
 
 }

--- a/src/client/ResetClient.ts
+++ b/src/client/ResetClient.ts
@@ -1,26 +1,12 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ResetRequest} from "../generated/com/digitalasset/ledger/api/v1/testing/reset_service_pb";
-import {Callback, justForward} from "../util/Callback";
+import {Callback} from "../util/Callback";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
-import {IResetServiceClient} from "../generated/com/digitalasset/ledger/api/v1/testing/reset_service_grpc_pb";
 
-export class ResetClient {
+export interface ResetClient {
 
-    private readonly request: ResetRequest;
-    private readonly client: IResetServiceClient;
-
-    constructor(ledgerId: string, client: IResetServiceClient) {
-        this.client = client;
-        this.request = new ResetRequest();
-        this.request.setLedgerId(ledgerId);
-    }
-
-    reset(callback: Callback<null>) {
-        return ClientCancellableCall.accept(this.client.reset(this.request, (error, _) => {
-            justForward(callback, error, null)
-        }));
-    }
+    reset(): Promise<null>
+    reset(callback: Callback<null>): ClientCancellableCall
 
 }

--- a/src/client/TimeClient.ts
+++ b/src/client/TimeClient.ts
@@ -1,36 +1,16 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {SetTimeRequestValidation} from "../validation/SetTimeRequestValidation";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
-import {Callback, justForward} from "../util/Callback";
+import {Callback} from "../util/Callback";
 import {SetTimeRequest} from "../model/SetTimeRequest";
 import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
 import {GetTimeResponse} from "../model/GetTimeResponse";
-import {isValid} from "../validation/Validation";
-import {GetTimeResponseCodec} from "../codec/GetTimeResponseCodec";
-import {SetTimeRequestCodec} from "../codec/SetTimeRequestCodec";
-import {GetTimeRequest} from "../generated/com/digitalasset/ledger/api/v1/testing/time_service_pb";
-import {ITimeServiceClient} from "../generated/com/digitalasset/ledger/api/v1/testing/time_service_grpc_pb";
-import {ValidationReporter} from "../reporting/ValidationReporter";
 
 /**
- * OptionalFieldsValidators service, exposed for testing static time scenarios.
+ * Optional service, exposed for testing static time scenarios.
  */
-export class TimeClient {
-
-    private readonly ledgerId: string;
-    private readonly request: GetTimeRequest;
-    private readonly client: ITimeServiceClient;
-    private readonly reporter: ValidationReporter;
-
-    constructor(ledgerId: string, client: ITimeServiceClient, reporter: ValidationReporter) {
-        this.ledgerId = ledgerId;
-        this.request = new GetTimeRequest();
-        this.request.setLedgerId(this.ledgerId);
-        this.client = client;
-        this.reporter = reporter;
-    }
+export interface TimeClient {
 
     /**
      * Returns a stream of time updates.
@@ -41,28 +21,13 @@ export class TimeClient {
      * Subsequent responses are emitted whenever the ledger server's time is
      * updated.
      */
-    getTime(): ClientReadableObjectStream<GetTimeResponse> {
-        return ClientReadableObjectStream.from(this.client.getTime(this.request), GetTimeResponseCodec);
-    }
+    getTime(): ClientReadableObjectStream<GetTimeResponse>
 
     /**
      * Allows clients to change the ledger's clock in an atomic get-and-set
      * operation.
      */
-    setTime(requestObject: SetTimeRequest, callback: Callback<null>): ClientCancellableCall {
-        const tree = SetTimeRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = SetTimeRequestCodec.serialize(requestObject);
-            request.setLedgerId(this.ledgerId);
-            return ClientCancellableCall.accept(this.client.setTime(request, (error, _) => {
-                justForward(callback, error, null)
-            }));
-        } else {
-            setImmediate(() => {
-                callback(new Error(this.reporter.render(tree)));
-            });
-            return ClientCancellableCall.rejected;
-        }
-    }
+    setTime(requestObject: SetTimeRequest): Promise<null>
+    setTime(requestObject: SetTimeRequest, callback: Callback<null>): ClientCancellableCall
 
 }

--- a/src/client/TimeClient.ts
+++ b/src/client/TimeClient.ts
@@ -27,7 +27,7 @@ export interface TimeClient {
      * Allows clients to change the ledger's clock in an atomic get-and-set
      * operation.
      */
-    setTime(requestObject: SetTimeRequest): Promise<null>
-    setTime(requestObject: SetTimeRequest, callback: Callback<null>): ClientCancellableCall
+    setTime(requestObject: SetTimeRequest): Promise<void>
+    setTime(requestObject: SetTimeRequest, callback: Callback<void>): ClientCancellableCall
 
 }

--- a/src/client/TransactionClient.ts
+++ b/src/client/TransactionClient.ts
@@ -1,47 +1,22 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ITransactionServiceClient} from "../generated/com/digitalasset/ledger/api/v1/transaction_service_grpc_pb";
-import {ValidationReporter} from "../reporting/ValidationReporter";
 import {ClientCancellableCall} from "../call/ClientCancellableCall";
-import {GetLedgerEndRequest} from "../generated/com/digitalasset/ledger/api/v1/transaction_service_pb";
 import {GetLedgerEndResponse} from "../model/GetLedgerEndResponse";
-import {Callback, forward} from "../util/Callback";
-import {GetLedgerEndResponseCodec} from "../codec/GetLedgerEndResponseCodec";
+import {Callback} from "../util/Callback";
 import {GetTransactionResponse} from "../model/GetTransactionResponse";
 import {GetTransactionByEventIdRequest} from "../model/GetTransactionByEventIdRequest";
-import {GetTransactionByEventIdRequestValidation} from "../validation/GetTransactionByEventIdRequestValidation";
-import {isValid} from "../validation/Validation";
-import {GetTransactionByEventIdRequestCodec} from "../codec/GetTransactionByEventIdRequestCodec";
-import {GetTransactionResponseCodec} from "../codec/GetTransactionResponseCodec";
-import {GetTransactionByIdRequestCodec} from "../codec/GetTransactionByIdRequestCodec";
 import {GetTransactionByIdRequest} from "../model/GetTransactionByIdRequest";
-import {GetTransactionsRequestValidation} from "../validation/GetTransactionsRequestValidation";
 import {GetTransactionsResponse} from "../model/GetTransactionsResponse";
 import {ClientReadableObjectStream} from "../call/ClientReadableObjectStream";
 import {GetTransactionsRequest} from "../model/GetTransactionsRequest";
-import {GetTransactionsRequestCodec} from "../codec/GetTransactionsRequestCodec";
-import {GetTransactionsResponseCodec} from "../codec/GetTransactionsResponseCodec";
 import {GetTransactionTreesResponse} from "../model/GetTransactionTreesResponse";
-import {GetTransactionTreesResponseCodec} from "../codec/GetTransactionTreesResponseCodec";
 import {GetFlatTransactionResponse} from "../model/GetFlatTransactionResponse";
-import {GetFlatTransactionResponseCodec} from "../codec/GetFlatTransactionResponseCodec";
-import {GetTransactionByIdRequestValidation} from "../validation/GetTransactionByIdRequestValidation";
 
 /**
  * Allows clients to read transactions from the ledger.
  */
-export class TransactionClient {
-
-    private readonly ledgerId: string;
-    private readonly client: ITransactionServiceClient;
-    private readonly reporter: ValidationReporter;
-
-    constructor(ledgerId: string, client: ITransactionServiceClient, reporter: ValidationReporter) {
-        this.ledgerId = ledgerId;
-        this.client = client;
-        this.reporter = reporter;
-    }
+export interface TransactionClient {
 
     /**
      * Get the current ledger end.
@@ -49,121 +24,51 @@ export class TransactionClient {
      * Subscriptions started with the returned offset will serve transactions
      * created after this RPC was called.
      */
-    getLedgerEnd(callback: Callback<GetLedgerEndResponse>): ClientCancellableCall {
-        const request = new GetLedgerEndRequest();
-        request.setLedgerId(this.ledgerId);
-        return ClientCancellableCall.accept(this.client.getLedgerEnd(request, (error, response) => {
-            forward(callback, error, response, GetLedgerEndResponseCodec.deserialize);
-        }));
-    }
+    getLedgerEnd(): Promise<GetLedgerEndResponse>
+    getLedgerEnd(callback: Callback<GetLedgerEndResponse>): ClientCancellableCall
 
     /**
      * Lookup a transaction by the ID of an event that appears within it.
      *
      * Returns NOT_FOUND if no such transaction exists.
      */
-    getTransactionByEventId(requestObject: GetTransactionByEventIdRequest, callback: Callback<GetTransactionResponse>): ClientCancellableCall {
-        const tree = GetTransactionByEventIdRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = GetTransactionByEventIdRequestCodec.serialize(requestObject);
-            request.setLedgerId(this.ledgerId);
-            return ClientCancellableCall.accept(this.client.getTransactionByEventId(request, (error, response) => {
-                forward(callback, error, response, GetTransactionResponseCodec.deserialize);
-            }));
-        } else {
-            setImmediate(() => callback(new Error(this.reporter.render(tree))));
-            return ClientCancellableCall.rejected;
-        }
-    }
+    getTransactionByEventId(requestObject: GetTransactionByEventIdRequest): Promise<GetTransactionResponse>
+    getTransactionByEventId(requestObject: GetTransactionByEventIdRequest, callback: Callback<GetTransactionResponse>): ClientCancellableCall
 
     /**
      * Lookup a transaction by the ID of an event that appears within it.
      *
      * Returns ``NOT_FOUND`` if no such transaction exists.
      */
-    getFlatTransactionByEventId(requestObject: GetTransactionByEventIdRequest, callback: Callback<GetFlatTransactionResponse>): ClientCancellableCall {
-        const tree = GetTransactionByEventIdRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = GetTransactionByEventIdRequestCodec.serialize(requestObject);
-            request.setLedgerId(this.ledgerId);
-            return ClientCancellableCall.accept(this.client.getFlatTransactionByEventId(request, (error, response) => {
-                forward(callback, error, response, GetFlatTransactionResponseCodec.deserialize);
-            }));
-        } else {
-            setImmediate(() => callback(new Error(this.reporter.render(tree))));
-            return ClientCancellableCall.rejected;
-        }
-    }
+    getFlatTransactionByEventId(requestObject: GetTransactionByEventIdRequest): Promise<GetFlatTransactionResponse>
+    getFlatTransactionByEventId(requestObject: GetTransactionByEventIdRequest, callback: Callback<GetFlatTransactionResponse>): ClientCancellableCall
 
     /**
      * Lookup a transaction by its ID.
      *
      * Returns NOT_FOUND if no such transaction exists.
      */
-    getTransactionById(requestObject: GetTransactionByIdRequest, callback: Callback<GetTransactionResponse>): ClientCancellableCall {
-        const tree = GetTransactionByIdRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = GetTransactionByIdRequestCodec.serialize(requestObject);
-            request.setLedgerId(this.ledgerId);
-            return ClientCancellableCall.accept(this.client.getTransactionById(request, (error, response) => {
-                forward(callback, error, response, GetTransactionResponseCodec.deserialize);
-            }));
-        } else {
-            setImmediate(() => callback(new Error(this.reporter.render(tree))));
-            return ClientCancellableCall.rejected;
-        }
-    }
+    getTransactionById(requestObject: GetTransactionByIdRequest): Promise<GetTransactionResponse>
+    getTransactionById(requestObject: GetTransactionByIdRequest, callback: Callback<GetTransactionResponse>): ClientCancellableCall
 
     /**
      * Lookup a transaction by the ID of an event that appears within it.
      *
      * Returns ``NOT_FOUND`` if no such transaction exists.
      */
-    getFlatTransactionById(requestObject: GetTransactionByIdRequest, callback: Callback<GetFlatTransactionResponse>): ClientCancellableCall {
-        const tree = GetTransactionByIdRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = GetTransactionByIdRequestCodec.serialize(requestObject);
-            request.setLedgerId(this.ledgerId);
-            return ClientCancellableCall.accept(this.client.getFlatTransactionById(request, (error, response) => {
-                forward(callback, error, response, GetFlatTransactionResponseCodec.deserialize);
-            }));
-        } else {
-            setImmediate(() => callback(new Error(this.reporter.render(tree))));
-            return ClientCancellableCall.rejected;
-        }
-    }
+    getFlatTransactionById(requestObject: GetTransactionByIdRequest): Promise<GetFlatTransactionResponse>
+    getFlatTransactionById(requestObject: GetTransactionByIdRequest, callback: Callback<GetFlatTransactionResponse>): ClientCancellableCall
 
     /**
      * Read the ledger's filtered transaction stream for a set of parties.
      */
-    getTransactions(requestObject: GetTransactionsRequest): ClientReadableObjectStream<GetTransactionsResponse> {
-        const tree = GetTransactionsRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = GetTransactionsRequestCodec.serialize(requestObject);
-            request.setLedgerId(this.ledgerId);
-            if (requestObject.verbose === undefined) {
-                request.setVerbose(true);
-            }
-            return ClientReadableObjectStream.from(this.client.getTransactions(request), GetTransactionsResponseCodec);
-        } else {
-            return ClientReadableObjectStream.from(new Error(this.reporter.render(tree)));
-        }
-    }
+    getTransactions(requestObject: GetTransactionsRequest): ClientReadableObjectStream<GetTransactionsResponse>
 
     /**
      * Read the ledger's complete transaction stream for a set of parties.
      *
      * This call is a future extension point and is currently not supported.
      */
-    getTransactionTrees(requestObject: GetTransactionsRequest): ClientReadableObjectStream<GetTransactionTreesResponse> {
-        const tree = GetTransactionsRequestValidation.validate(requestObject);
-        if (isValid(tree)) {
-            const request = GetTransactionsRequestCodec.serialize(requestObject);
-            request.setLedgerId(this.ledgerId);
-            return ClientReadableObjectStream.from(this.client.getTransactionTrees(request), GetTransactionTreesResponseCodec);
-        } else {
-            return ClientReadableObjectStream.from(new Error(this.reporter.render(tree)));
-        }
-    }
+    getTransactionTrees(requestObject: GetTransactionsRequest): ClientReadableObjectStream<GetTransactionTreesResponse>
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {NodeJsLedgerConfigurationClient} from "./client/NodeJsLedgerConfiguratio
 import {NodeJsLedgerIdentityClient} from "./client/NodeJsLedgerIdentityClient";
 import {NodeJsPackageClient} from "./client/NodeJsPackageClient";
 import {NodeJsResetClient} from "./client/NodeJsResetClient";
-import {TimeClient} from "./client/TimeClient";
+import {NodeJsTimeClient} from "./client/NodeJsTimeClient";
 import {TransactionClient} from "./client/TransactionClient";
 export {
     NodeJsActiveContractsClient as ActiveContractsClient,
@@ -23,8 +23,8 @@ export {
     NodeJsLedgerConfigurationClient as LedgerConfigurationClient,
     NodeJsLedgerIdentityClient as LedgerIdentityClient,
     NodeJsPackageClient as PackageClient,
-    NodeJsResetClient,
-    TimeClient,
+    NodeJsResetClient as ResetClient,
+    NodeJsTimeClient as TimeClient,
     TransactionClient
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {NodeJsLedgerIdentityClient} from "./client/NodeJsLedgerIdentityClient";
 import {NodeJsPackageClient} from "./client/NodeJsPackageClient";
 import {NodeJsResetClient} from "./client/NodeJsResetClient";
 import {NodeJsTimeClient} from "./client/NodeJsTimeClient";
-import {TransactionClient} from "./client/TransactionClient";
+import {NodeJsTransactionClient} from "./client/NodeJsTransactionClient";
 export {
     NodeJsActiveContractsClient as ActiveContractsClient,
     NodeJsCommandClient as CommandClient,
@@ -25,7 +25,7 @@ export {
     NodeJsPackageClient as PackageClient,
     NodeJsResetClient as ResetClient,
     NodeJsTimeClient as TimeClient,
-    TransactionClient
+    NodeJsTransactionClient as TransactionClient
 };
 
 import * as lf from './generated/da/daml_lf_pb';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,20 +9,20 @@ import {DamlLedgerClient} from "./client/DamlLedgerClient";
 import {LedgerClient} from "./client/LedgerClient";
 import {NodeJsLedgerConfigurationClient} from "./client/NodeJsLedgerConfigurationClient";
 import {NodeJsLedgerIdentityClient} from "./client/NodeJsLedgerIdentityClient";
-import {PackageClient} from "./client/PackageClient";
+import {NodeJsPackageClient} from "./client/NodeJsPackageClient";
 import {ResetClient} from "./client/ResetClient";
 import {TimeClient} from "./client/TimeClient";
 import {TransactionClient} from "./client/TransactionClient";
 export {
-    NodeJsActiveContractsClient,
-    NodeJsCommandClient,
-    NodeJsCommandCompletionClient,
-    NodeJsCommandSubmissionClient,
+    NodeJsActiveContractsClient as ActiveContractsClient,
+    NodeJsCommandClient as CommandClient,
+    NodeJsCommandCompletionClient as CommandCompletionClient,
+    NodeJsCommandSubmissionClient as CommandSubmissionClient,
     DamlLedgerClient,
     LedgerClient,
-    NodeJsLedgerConfigurationClient,
-    NodeJsLedgerIdentityClient,
-    PackageClient,
+    NodeJsLedgerConfigurationClient as LedgerConfigurationClient,
+    NodeJsLedgerIdentityClient as LedgerIdentityClient,
+    NodeJsPackageClient as PackageClient,
     ResetClient,
     TimeClient,
     TransactionClient

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {NodeJsCommandCompletionClient} from "./client/NodeJsCommandCompletionCli
 import {NodeJsCommandSubmissionClient} from "./client/NodeJsCommandSubmissionClient";
 import {DamlLedgerClient} from "./client/DamlLedgerClient";
 import {LedgerClient} from "./client/LedgerClient";
-import {LedgerConfigurationClient} from "./client/LedgerConfigurationClient";
+import {NodeJsLedgerConfigurationClient} from "./client/NodeJsLedgerConfigurationClient";
 import {LedgerIdentityClient} from "./client/LedgerIdentityClient";
 import {PackageClient} from "./client/PackageClient";
 import {ResetClient} from "./client/ResetClient";
@@ -20,7 +20,7 @@ export {
     NodeJsCommandSubmissionClient,
     DamlLedgerClient,
     LedgerClient,
-    LedgerConfigurationClient,
+    NodeJsLedgerConfigurationClient,
     LedgerIdentityClient,
     PackageClient,
     ResetClient,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {LedgerClient} from "./client/LedgerClient";
 import {NodeJsLedgerConfigurationClient} from "./client/NodeJsLedgerConfigurationClient";
 import {NodeJsLedgerIdentityClient} from "./client/NodeJsLedgerIdentityClient";
 import {NodeJsPackageClient} from "./client/NodeJsPackageClient";
-import {ResetClient} from "./client/ResetClient";
+import {NodeJsResetClient} from "./client/NodeJsResetClient";
 import {TimeClient} from "./client/TimeClient";
 import {TransactionClient} from "./client/TransactionClient";
 export {
@@ -23,7 +23,7 @@ export {
     NodeJsLedgerConfigurationClient as LedgerConfigurationClient,
     NodeJsLedgerIdentityClient as LedgerIdentityClient,
     NodeJsPackageClient as PackageClient,
-    ResetClient,
+    NodeJsResetClient,
     TimeClient,
     TransactionClient
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@
 
 import {NodeJsActiveContractsClient} from "./client/NodeJsActiveContractsClient";
 import {NodeJsCommandClient} from "./client/NodeJsCommandClient";
-import {CommandCompletionClient} from "./client/CommandCompletionClient";
-import {CommandSubmissionClient} from "./client/CommandSubmissionClient";
+import {NodeJsCommandCompletionClient} from "./client/NodeJsCommandCompletionClient";
+import {NodeJsCommandSubmissionClient} from "./client/NodeJsCommandSubmissionClient";
 import {DamlLedgerClient} from "./client/DamlLedgerClient";
 import {LedgerClient} from "./client/LedgerClient";
 import {LedgerConfigurationClient} from "./client/LedgerConfigurationClient";
@@ -16,8 +16,8 @@ import {TransactionClient} from "./client/TransactionClient";
 export {
     NodeJsActiveContractsClient,
     NodeJsCommandClient,
-    CommandCompletionClient,
-    CommandSubmissionClient,
+    NodeJsCommandCompletionClient,
+    NodeJsCommandSubmissionClient,
     DamlLedgerClient,
     LedgerClient,
     LedgerConfigurationClient,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ActiveContractsClient} from "./client/ActiveContractsClient";
+import {NodeJsActiveContractsClient} from "./client/NodeJsActiveContractsClient";
 import {NodeJsCommandClient} from "./client/NodeJsCommandClient";
 import {CommandCompletionClient} from "./client/CommandCompletionClient";
 import {CommandSubmissionClient} from "./client/CommandSubmissionClient";
@@ -14,7 +14,7 @@ import {ResetClient} from "./client/ResetClient";
 import {TimeClient} from "./client/TimeClient";
 import {TransactionClient} from "./client/TransactionClient";
 export {
-    ActiveContractsClient,
+    NodeJsActiveContractsClient,
     NodeJsCommandClient,
     CommandCompletionClient,
     CommandSubmissionClient,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {ActiveContractsClient} from "./client/ActiveContractsClient";
-import {CommandClient} from "./client/CommandClient";
+import {NodeJsCommandClient} from "./client/NodeJsCommandClient";
 import {CommandCompletionClient} from "./client/CommandCompletionClient";
 import {CommandSubmissionClient} from "./client/CommandSubmissionClient";
 import {DamlLedgerClient} from "./client/DamlLedgerClient";
@@ -15,7 +15,7 @@ import {TimeClient} from "./client/TimeClient";
 import {TransactionClient} from "./client/TransactionClient";
 export {
     ActiveContractsClient,
-    CommandClient,
+    NodeJsCommandClient,
     CommandCompletionClient,
     CommandSubmissionClient,
     DamlLedgerClient,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {NodeJsCommandSubmissionClient} from "./client/NodeJsCommandSubmissionCli
 import {DamlLedgerClient} from "./client/DamlLedgerClient";
 import {LedgerClient} from "./client/LedgerClient";
 import {NodeJsLedgerConfigurationClient} from "./client/NodeJsLedgerConfigurationClient";
-import {LedgerIdentityClient} from "./client/LedgerIdentityClient";
+import {NodeJsLedgerIdentityClient} from "./client/NodeJsLedgerIdentityClient";
 import {PackageClient} from "./client/PackageClient";
 import {ResetClient} from "./client/ResetClient";
 import {TimeClient} from "./client/TimeClient";
@@ -21,7 +21,7 @@ export {
     DamlLedgerClient,
     LedgerClient,
     NodeJsLedgerConfigurationClient,
-    LedgerIdentityClient,
+    NodeJsLedgerIdentityClient,
     PackageClient,
     ResetClient,
     TimeClient,

--- a/src/model/GetTransactionTreesResponse.ts
+++ b/src/model/GetTransactionTreesResponse.ts
@@ -48,7 +48,7 @@ import {TransactionTree} from "./TransactionTree";
 export interface GetTransactionTreesResponse {
 
     /**
-     * The list of transaction trees that matches the filter in {@link GetTransactionsRequest} for the {@link TransactionClient.getTransactionTrees} method.
+     * A list of transaction trees.
      */
     transactions: TransactionTree[]
 

--- a/src/model/GetTransactionsResponse.ts
+++ b/src/model/GetTransactionsResponse.ts
@@ -52,7 +52,7 @@ import {Transaction} from "./Transaction";
 export interface GetTransactionsResponse {
 
     /**
-     * The list of transactions that matches the filter in {@link GetTransactionsRequest} for the {@link TransactionClient.getTransactions} method.
+     * A list of transactions.
      */
     transactions: Transaction[]
 }

--- a/src/util/Callback.ts
+++ b/src/util/Callback.ts
@@ -12,7 +12,7 @@ export type Callback<A> = (error: Error | null, response?: A) => void
 
 type Call<Request, Response> = (request: Request, callback: Callback<Response>) => ClientCancellableCall
 
-type PromisifiedCall<Request, Response> = (request: Request) => Promise<Response>
+type PromisifiedCall<Request, Response> = (request?: Request) => Promise<Response>
 
 export function promisify<Request, Response>(call: Call<Request, Response>): PromisifiedCall<Request, Response> {
     return _promisify(call) as PromisifiedCall<Request, Response>;

--- a/src/util/Callback.ts
+++ b/src/util/Callback.ts
@@ -5,7 +5,18 @@
  * A callback that will either receive an Error or a valid response,
  * depending on the result of the operation.
  */
+import {ClientCancellableCall} from "../call/ClientCancellableCall";
+import {promisify as _promisify} from "util";
+
 export type Callback<A> = (error: Error | null, response?: A) => void
+
+type Call<Request, Response> = (request: Request, callback: Callback<Response>) => ClientCancellableCall
+
+type PromisifiedCall<Request, Response> = (request: Request) => Promise<Response>
+
+export function promisify<Request, Response>(call: Call<Request, Response>): PromisifiedCall<Request, Response> {
+    return _promisify(call) as PromisifiedCall<Request, Response>;
+}
 
 export function justForward<A>(callback: Callback<A>, error: Error | null, response: A): void {
     forward(callback, error, response, (a: A) => a);

--- a/src/util/Callback.ts
+++ b/src/util/Callback.ts
@@ -18,8 +18,8 @@ export function promisify<Request, Response>(call: Call<Request, Response>): Pro
     return _promisify(call) as PromisifiedCall<Request, Response>;
 }
 
-export function justForward<A>(callback: Callback<A>, error: Error | null, response: A): void {
-    forward(callback, error, response, (a: A) => a);
+export function forwardVoidResponse(callback: Callback<void>, error: Error | null): void {
+    forward(callback, error, undefined, () => {});
 }
 
 export function forward<A, B>(callback: Callback<B>, error: Error | null, response: A, process: (_: A) => B): void {

--- a/test/client/ActiveContractsClient.spec.ts
+++ b/test/client/ActiveContractsClient.spec.ts
@@ -6,19 +6,19 @@ import * as sinon from 'sinon';
 import {
     GetActiveContractsRequest as PbGetActiveContractsRequest
 } from "../../src/generated/com/digitalasset/ledger/api/v1/active_contracts_service_pb";
-import {ActiveContractsClient} from "../../src/client/ActiveContractsClient";
+import {NodeJsActiveContractsClient} from "../../src/client/NodeJsActiveContractsClient";
 import {JSONReporter} from "../../src/reporting/JSONReporter";
 import {GetActiveContractsRequestCodec} from "../../src/codec/GetActiveContractsRequestCodec";
 import {ValidationTree} from "../../src/validation/Validation";
 import {GetActiveContractsRequest} from "../../src/model/GetActiveContractsRequest";
 import {DummyActiveContractsServiceClient} from "./DummyActiveContractsServiceClient";
 
-describe("ActiveContractsClient", () => {
+describe("NodeJsActiveContractsClient", () => {
 
     const ledgerId = 'some-ledger-id';
     const latestRequestSpy = sinon.spy();
     const dummy = new DummyActiveContractsServiceClient(latestRequestSpy);
-    const client = new ActiveContractsClient(ledgerId, dummy, JSONReporter);
+    const client = new NodeJsActiveContractsClient(ledgerId, dummy, JSONReporter);
 
     afterEach(() => {
         sinon.restore();

--- a/test/client/CommandClient.spec.ts
+++ b/test/client/CommandClient.spec.ts
@@ -5,13 +5,13 @@ import {assert, expect} from 'chai';
 import * as sinon from 'sinon';
 import {SubmitAndWaitRequest} from "../../src/model/SubmitAndWaitRequest";
 import {SubmitAndWaitRequest as PbSubmitAndWaitRequest} from "../../src/generated/com/digitalasset/ledger/api/v1/command_service_pb";
-import {CommandClient} from "../../src/client/CommandClient";
+import {NodeJsCommandClient} from "../../src/client/NodeJsCommandClient";
 import {JSONReporter} from "../../src/reporting/JSONReporter";
 import {SubmitAndWaitRequestCodec} from "../../src/codec/SubmitAndWaitRequestCodec";
 import {ValidationTree} from "../../src/validation/Validation";
 import {DummyCommandServiceClient} from "./DummyCommandServiceClient";
 
-describe("CommandClient", () => {
+describe("NodeJsCommandClient", () => {
 
     afterEach(() => {
         sinon.restore();
@@ -125,7 +125,7 @@ describe("CommandClient", () => {
     const ledgerId = 'some-ledger-id';
     const latestRequestSpy = sinon.spy();
     const dummy = new DummyCommandServiceClient(latestRequestSpy);
-    const client = new CommandClient(ledgerId, dummy, JSONReporter);
+    const client = new NodeJsCommandClient(ledgerId, dummy, JSONReporter);
 
     it('should correctly forward a command on the SubmitAndWait endpoint', (done) => {
         client.submitAndWait(request, (error, _) => {
@@ -135,6 +135,13 @@ describe("CommandClient", () => {
             expect(SubmitAndWaitRequestCodec.deserialize(latestRequestSpy.lastCall.lastArg)).to.deep.equal(request);
             done();
         });
+    });
+
+    it('should correctly forward a command on the SubmitAndWait endpoint (promisified)', async () => {
+        await client.submitAndWait(request);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(SubmitAndWaitRequestCodec.deserialize(latestRequestSpy.lastCall.lastArg)).to.deep.equal(request);
     });
 
     it('should set the ledger identifier properly on the SubmitAndWait endpoint', (done) => {
@@ -148,6 +155,14 @@ describe("CommandClient", () => {
         });
     });
 
+    it('should set the ledger identifier properly on the SubmitAndWait endpoint (promisified)', async () => {
+        await client.submitAndWait(request);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbSubmitAndWaitRequest;
+        expect(spiedRequest.getCommands()!.getLedgerId()).to.deep.equal(ledgerId);
+    });
+
     it('should perform validation on the SubmitAndWait endpoint', (done) => {
         client.submitAndWait(invalidRequest, error => {
             expect(error).to.not.be.null;
@@ -155,9 +170,21 @@ describe("CommandClient", () => {
             client.submitAndWaitForTransactionId(invalidRequest as any as SubmitAndWaitRequest, error => {
                 expect(error).to.not.be.null;
                 expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTree);
-                done()
+                done();
             });
         });
+    });
+
+    it('should perform validation on the SubmitAndWait endpoint (promisified)', async () => {
+        let errorThrown = false;
+        try {
+            await client.submitAndWait(invalidRequest);
+        } catch (error) {
+            expect(error).to.not.be.null;
+            expect(JSON.parse(error.message)).to.deep.equal(expectedValidationTree);
+            errorThrown = true;
+        }
+        assert(errorThrown, 'an error was expected but none has been thrown');
     });
 
     it('should correctly forward a command on the SubmitAndWaitForTransaction endpoint', (done) => {
@@ -170,6 +197,13 @@ describe("CommandClient", () => {
         });
     });
 
+    it('should correctly forward a command on the SubmitAndWaitForTransaction endpoint (promisified)', async () => {
+        await client.submitAndWaitForTransaction(request);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(SubmitAndWaitRequestCodec.deserialize(latestRequestSpy.lastCall.lastArg)).to.deep.equal(request);
+    });
+
     it('should set the ledger identifier properly on the SubmitAndWaitForTransaction endpoint', (done) => {
         client.submitAndWaitForTransaction(request, (error, _) => {
             expect(error).to.be.null;
@@ -179,6 +213,14 @@ describe("CommandClient", () => {
             expect(request.getCommands()!.getLedgerId()).to.deep.equal(ledgerId);
             done();
         });
+    });
+
+    it('should set the ledger identifier properly on the SubmitAndWaitForTransaction endpoint (promisified)', async () => {
+        await client.submitAndWaitForTransaction(request);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbSubmitAndWaitRequest;
+        expect(spiedRequest.getCommands()!.getLedgerId()).to.deep.equal(ledgerId);
     });
 
     it('should perform validation on the SubmitAndWaitForTransaction endpoint', (done) => {
@@ -193,6 +235,18 @@ describe("CommandClient", () => {
         });
     });
 
+    it('should perform validation on the SubmitAndWaitForTransaction endpoint (promisified)', async () => {
+        let errorThrown = false;
+        try {
+            await client.submitAndWaitForTransaction(invalidRequest);
+        } catch (error) {
+            expect(error).to.not.be.null;
+            expect(JSON.parse(error.message)).to.deep.equal(expectedValidationTree);
+            errorThrown = true;
+        }
+        assert(errorThrown, 'an error was expected but none has been thrown');
+    });
+
     it('should correctly forward a command on the SubmitAndWaitForTransactionId endpoint', (done) => {
         client.submitAndWaitForTransactionId(request, (error, _) => {
             expect(error).to.be.null;
@@ -201,6 +255,13 @@ describe("CommandClient", () => {
             expect(SubmitAndWaitRequestCodec.deserialize(latestRequestSpy.lastCall.lastArg)).to.deep.equal(request);
             done();
         });
+    });
+
+    it('should correctly forward a command on the SubmitAndWaitForTransactionId endpoint (promisified)', async () => {
+        await client.submitAndWaitForTransactionId(request);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(SubmitAndWaitRequestCodec.deserialize(latestRequestSpy.lastCall.lastArg)).to.deep.equal(request);
     });
 
     it('should set the ledger identifier properly on the SubmitAndWaitForTransactionId endpoint', (done) => {
@@ -212,6 +273,14 @@ describe("CommandClient", () => {
             expect(request.getCommands()!.getLedgerId()).to.deep.equal(ledgerId);
             done();
         });
+    });
+
+    it('should set the ledger identifier properly on the SubmitAndWaitForTransactionId endpoint (promisified)', async () => {
+        await client.submitAndWaitForTransactionId(request);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbSubmitAndWaitRequest;
+        expect(spiedRequest.getCommands()!.getLedgerId()).to.deep.equal(ledgerId);
     });
 
     it('should perform validation on the SubmitAndWaitForTransactionId endpoint', (done) => {
@@ -226,6 +295,18 @@ describe("CommandClient", () => {
         });
     });
 
+    it('should perform validation on the SubmitAndWaitForTransactionId endpoint (promisified)', async () => {
+        let errorThrown = false;
+        try {
+            await client.submitAndWaitForTransactionId(invalidRequest);
+        } catch (error) {
+            expect(error).to.not.be.null;
+            expect(JSON.parse(error.message)).to.deep.equal(expectedValidationTree);
+            errorThrown = true;
+        }
+        assert(errorThrown, 'an error was expected but none has been thrown');
+    });
+
     it('should correctly forward a command on the SubmitAndWaitForTransactionTree endpoint', (done) => {
         client.submitAndWaitForTransactionTree(request, (error, _) => {
             expect(error).to.be.null;
@@ -234,6 +315,13 @@ describe("CommandClient", () => {
             expect(SubmitAndWaitRequestCodec.deserialize(latestRequestSpy.lastCall.lastArg)).to.deep.equal(request);
             done();
         });
+    });
+
+    it('should correctly forward a command on the SubmitAndWaitForTransactionTree endpoint (promisified)', async () => {
+        await client.submitAndWaitForTransactionTree(request);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(SubmitAndWaitRequestCodec.deserialize(latestRequestSpy.lastCall.lastArg)).to.deep.equal(request);
     });
 
     it('should set the ledger identifier properly on the SubmitAndWaitForTransactionTree endpoint', (done) => {
@@ -247,6 +335,14 @@ describe("CommandClient", () => {
         });
     });
 
+    it('should set the ledger identifier properly on the SubmitAndWaitForTransactionTree endpoint (promisified)', async () => {
+        await client.submitAndWaitForTransactionTree(request);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbSubmitAndWaitRequest;
+        expect(spiedRequest.getCommands()!.getLedgerId()).to.deep.equal(ledgerId);
+    });
+
     it('should perform validation on the SubmitAndWaitForTransactionTree endpoint', (done) => {
         client.submitAndWaitForTransactionTree(invalidRequest, error => {
             expect(error).to.not.be.null;
@@ -257,6 +353,18 @@ describe("CommandClient", () => {
                 done()
             });
         });
+    });
+
+    it('should perform validation on the SubmitAndWaitForTransactionTree endpoint (promisified)', async () => {
+        let errorThrown = false;
+        try {
+            await client.submitAndWaitForTransactionTree(invalidRequest);
+        } catch (error) {
+            expect(error).to.not.be.null;
+            expect(JSON.parse(error.message)).to.deep.equal(expectedValidationTree);
+            errorThrown = true;
+        }
+        assert(errorThrown, 'an error was expected but none has been thrown');
     });
 
 });

--- a/test/client/CommandCompletionClient.spec.ts
+++ b/test/client/CommandCompletionClient.spec.ts
@@ -3,7 +3,6 @@
 
 import {assert, expect} from 'chai';
 import * as sinon from 'sinon';
-import {CommandCompletionClient} from "../../src/client/CommandCompletionClient";
 import {JSONReporter} from "../../src/reporting/JSONReporter";
 import {
     CompletionEndRequest as PbCompletionEndRequest,
@@ -13,21 +12,22 @@ import {CompletionStreamRequestCodec} from "../../src/codec/CompletionStreamRequ
 import {ValidationTree} from "../../src/validation/Validation";
 import {CompletionStreamRequest} from "../../src/model/CompletionStreamRequest";
 import {DummyCommandCompletionServiceClient} from "./DummyCommandCompletionServiceClient";
+import {NodeJsCommandCompletionClient} from "../../src/client/NodeJsCommandCompletionClient";
 
-describe('CommandCompletionClient', () => {
+describe('NodeJsCommandCompletionClient', () => {
 
     const ledgerId = 'cafebabe';
 
     const latestRequestSpy = sinon.spy();
     const dummy = new DummyCommandCompletionServiceClient(latestRequestSpy);
-    const client = new CommandCompletionClient(ledgerId, dummy, JSONReporter);
+    const client = new NodeJsCommandCompletionClient(ledgerId, dummy, JSONReporter);
 
     afterEach(() => {
         sinon.restore();
         latestRequestSpy.resetHistory();
     });
 
-    it('should send the correct ledger identifier', (done) => {
+    it('should send the correct request', (done) => {
 
         client.completionEnd((error, _response) => {
             expect(error).to.be.null;
@@ -38,6 +38,18 @@ describe('CommandCompletionClient', () => {
             expect(request.getLedgerId()).to.equal(ledgerId);
             done();
         });
+
+    });
+
+    it('should send the correct request (promisified)', async () => {
+
+        await client.completionEnd();
+
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbCompletionEndRequest);
+        const request = latestRequestSpy.lastCall.lastArg as PbCompletionEndRequest;
+        expect(request.getLedgerId()).to.equal(ledgerId);
 
     });
 

--- a/test/client/LedgerClient.spec.ts
+++ b/test/client/LedgerClient.spec.ts
@@ -257,7 +257,7 @@ describe("DamlLedgerClient", () => {
             const call = client!.transactionClient.getTransactions({
                 filter: {filtersByParty: {}},
                 begin: {offsetType:'absolute',absolute: '0'}
-            })
+            });
             call.on('end', () => {
                 assert(spy.calledOnceWithExactly(ledgerId));
                 done();
@@ -271,7 +271,7 @@ describe("DamlLedgerClient", () => {
             const call = client!.transactionClient.getTransactionTrees({
                 filter: {filtersByParty: {}},
                 begin: {offsetType:'absolute',absolute: '0'}
-            })
+            });
             call.on('end', () => {
                 assert(spy.calledOnceWithExactly(ledgerId));
                 done();
@@ -279,7 +279,7 @@ describe("DamlLedgerClient", () => {
         });
     });
 
-    it('should correctly set the ledgerId of the TimeClient (getTime)', (done) => {
+    it('should correctly set the ledgerId of the NodeJsTimeClient (getTime)', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
             const call = client!.timeClient.getTime();
@@ -290,7 +290,14 @@ describe("DamlLedgerClient", () => {
         });
     });
 
-    it('should correctly set the ledgerId of the TimeClient (setTime)', (done) => {
+    it('should correctly set the ledgerId of the NodeJsTimeClient (getTime -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        const time = client.timeClient.getTime();
+        for await (const _ of time) {} // consume mocked stream completely
+        assert(spy.calledOnceWithExactly(ledgerId));
+    });
+
+    it('should correctly set the ledgerId of the NodeJsTimeClient (setTime)', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
             client!.timeClient.setTime({
@@ -302,6 +309,15 @@ describe("DamlLedgerClient", () => {
                 done();
             });
         });
+    });
+
+    it('should correctly set the ledgerId of the NodeJsTimeClient (setTime -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.timeClient.setTime({
+            currentTime: {seconds: 0, nanoseconds: 0},
+            newTime: {seconds: 0, nanoseconds: 1}
+        });
+        assert(spy.calledOnceWithExactly(ledgerId));
     });
 
     it('should correctly set the ledgerId of the NodeJsResetClient', (done) => {

--- a/test/client/LedgerClient.spec.ts
+++ b/test/client/LedgerClient.spec.ts
@@ -229,6 +229,12 @@ describe("DamlLedgerClient", () => {
         });
     });
 
+    it('should correctly set the ledgerId of the TransactionsClient (getLedgerEnd -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.transactionClient.getLedgerEnd();
+        assert(spy.calledOnceWithExactly(ledgerId));
+    });
+
     it('should correctly set the ledgerId of the TransactionsClient (getTransactionByEventId)', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -240,6 +246,12 @@ describe("DamlLedgerClient", () => {
         });
     });
 
+    it('should correctly set the ledgerId of the TransactionsClient (getTransactionByEventId -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.transactionClient.getTransactionByEventId({eventId: '', requestingParties: []});
+        assert(spy.calledOnceWithExactly(ledgerId));
+    });
+
     it('should correctly set the ledgerId of the TransactionsClient (getTransactionById)', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -249,6 +261,12 @@ describe("DamlLedgerClient", () => {
                 done();
             });
         });
+    });
+
+    it('should correctly set the ledgerId of the TransactionsClient (getTransactionById -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.transactionClient.getTransactionById({transactionId: '', requestingParties: []});
+        assert(spy.calledOnceWithExactly(ledgerId));
     });
 
     it('should correctly set the ledgerId of the TransactionsClient (getTransactions)', (done) => {
@@ -265,6 +283,16 @@ describe("DamlLedgerClient", () => {
         });
     });
 
+    it('should correctly set the ledgerId of the TransactionsClient (getTransactions -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        const transactions = client.transactionClient.getTransactions({
+            filter: {filtersByParty: {}},
+            begin: {offsetType:'absolute',absolute: '0'}
+        });
+        for await (const _ of transactions) {} // consume the mocked stream completely
+        assert(spy.calledOnceWithExactly(ledgerId));
+    });
+
     it('should correctly set the ledgerId of the TransactionsClient (getTransactionTrees)', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -277,6 +305,16 @@ describe("DamlLedgerClient", () => {
                 done();
             });
         });
+    });
+
+    it('should correctly set the ledgerId of the TransactionsClient (getTransactionTrees -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        const transactions = client.transactionClient.getTransactionTrees({
+            filter: {filtersByParty: {}},
+            begin: {offsetType:'absolute',absolute: '0'}
+        });
+        for await (const _ of transactions) {} // consume the mocked stream completely
+        assert(spy.calledOnceWithExactly(ledgerId));
     });
 
     it('should correctly set the ledgerId of the NodeJsTimeClient (getTime)', (done) => {

--- a/test/client/LedgerClient.spec.ts
+++ b/test/client/LedgerClient.spec.ts
@@ -46,6 +46,11 @@ describe("DamlLedgerClient", () => {
         });
     });
 
+    it('should properly initialize the ledgerId (promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        expect(client.ledgerId).to.equal(ledgerId);
+    });
+
     it('should correctly set the ledgerId of the ActiveContractService', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -60,6 +65,13 @@ describe("DamlLedgerClient", () => {
         });
     });
 
+    it('should correctly set the ledgerId of the ActiveContractService (promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        const activeContracts = client.activeContractsClient.getActiveContracts({filter: {filtersByParty: {}}});
+        for await (const _ of activeContracts) {} // fully consume the active contracts
+        expect(spy.calledOnceWithExactly(ledgerId)).to.be.true
+    });
+
     it('should correctly set the ledgerId of the CommandService', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -69,6 +81,12 @@ describe("DamlLedgerClient", () => {
                 done();
             });
         });
+    });
+
+    it('should correctly set the ledgerId of the CommandService (promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.commandClient.submitAndWait(emptyCommands);
+        assert(spy.calledOnceWithExactly(ledgerId));
     });
 
     it('should correctly set the ledgerId of the CommandCompletionService (completionStream)', (done) => {
@@ -86,6 +104,17 @@ describe("DamlLedgerClient", () => {
         });
     });
 
+    it('should correctly set the ledgerId of the CommandCompletionService (completionStream -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        const completions = client.commandCompletionClient.completionStream({
+            applicationId: '',
+            offset: {offsetType:'absolute',absolute: '0'},
+            parties: []
+        });
+        for await (const _ of completions) {} // consume the completions to the very end
+        expect(spy.calledOnceWithExactly(ledgerId)).to.be.true
+    });
+
     it('should correctly set the ledgerId of the CommandCompletionService (completionEnd)', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -97,6 +126,12 @@ describe("DamlLedgerClient", () => {
         })
     });
 
+    it('should correctly set the ledgerId of the CommandCompletionService (completionEnd -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.commandCompletionClient.completionEnd();
+        assert(spy.calledOnceWithExactly(ledgerId));
+    });
+
     it('should correctly set the ledgerId of the CommandSubmissionService', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -106,6 +141,12 @@ describe("DamlLedgerClient", () => {
                 done();
             });
         });
+    });
+
+    it('should correctly set the ledgerId of the CommandSubmissionService (promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.commandSubmissionClient.submit(emptyCommands);
+        assert(spy.calledOnceWithExactly(ledgerId));
     });
 
     it('should correctly set the ledgerId of the PackageService (listPackages)', (done) => {

--- a/test/client/LedgerClient.spec.ts
+++ b/test/client/LedgerClient.spec.ts
@@ -304,7 +304,7 @@ describe("DamlLedgerClient", () => {
         });
     });
 
-    it('should correctly set the ledgerId of the ResetClient', (done) => {
+    it('should correctly set the ledgerId of the NodeJsResetClient', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
             client!.resetClient.reset((error, _) => {
@@ -313,6 +313,12 @@ describe("DamlLedgerClient", () => {
                 done();
             });
         });
+    });
+
+    it('should correctly set the ledgerId of the NodeJsResetClient (promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.resetClient.reset();
+        assert(spy.calledOnceWithExactly(ledgerId));
     });
 
 });

--- a/test/client/LedgerClient.spec.ts
+++ b/test/client/LedgerClient.spec.ts
@@ -65,13 +65,6 @@ describe("DamlLedgerClient", () => {
         });
     });
 
-    it('should correctly set the ledgerId of the ActiveContractService (promisified)', async () => {
-        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
-        const activeContracts = client.activeContractsClient.getActiveContracts({filter: {filtersByParty: {}}});
-        for await (const _ of activeContracts) {} // fully consume the active contracts
-        expect(spy.calledOnceWithExactly(ledgerId)).to.be.true
-    });
-
     it('should correctly set the ledgerId of the CommandService', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -102,17 +95,6 @@ describe("DamlLedgerClient", () => {
                 done();
             });
         });
-    });
-
-    it('should correctly set the ledgerId of the CommandCompletionService (completionStream -- promisified)', async () => {
-        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
-        const completions = client.commandCompletionClient.completionStream({
-            applicationId: '',
-            offset: {offsetType:'absolute',absolute: '0'},
-            parties: []
-        });
-        for await (const _ of completions) {} // consume the completions to the very end
-        expect(spy.calledOnceWithExactly(ledgerId)).to.be.true
     });
 
     it('should correctly set the ledgerId of the CommandCompletionService (completionEnd)', (done) => {
@@ -211,13 +193,6 @@ describe("DamlLedgerClient", () => {
         });
     });
 
-    it('should correctly set the ledgerId of the LedgerConfigurationService (promisified)', async () => {
-        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
-        const changes = client.ledgerConfigurationClient.getLedgerConfiguration();
-        for await (const _ of changes) {} // consume mocked stream completely
-        assert(spy.calledOnceWithExactly(ledgerId));
-    });
-
     it('should correctly set the ledgerId of the TransactionsClient (getLedgerEnd)', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -283,16 +258,6 @@ describe("DamlLedgerClient", () => {
         });
     });
 
-    it('should correctly set the ledgerId of the TransactionsClient (getTransactions -- promisified)', async () => {
-        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
-        const transactions = client.transactionClient.getTransactions({
-            filter: {filtersByParty: {}},
-            begin: {offsetType:'absolute',absolute: '0'}
-        });
-        for await (const _ of transactions) {} // consume the mocked stream completely
-        assert(spy.calledOnceWithExactly(ledgerId));
-    });
-
     it('should correctly set the ledgerId of the TransactionsClient (getTransactionTrees)', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -307,16 +272,6 @@ describe("DamlLedgerClient", () => {
         });
     });
 
-    it('should correctly set the ledgerId of the TransactionsClient (getTransactionTrees -- promisified)', async () => {
-        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
-        const transactions = client.transactionClient.getTransactionTrees({
-            filter: {filtersByParty: {}},
-            begin: {offsetType:'absolute',absolute: '0'}
-        });
-        for await (const _ of transactions) {} // consume the mocked stream completely
-        assert(spy.calledOnceWithExactly(ledgerId));
-    });
-
     it('should correctly set the ledgerId of the NodeJsTimeClient (getTime)', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -326,13 +281,6 @@ describe("DamlLedgerClient", () => {
                 done();
             });
         });
-    });
-
-    it('should correctly set the ledgerId of the NodeJsTimeClient (getTime -- promisified)', async () => {
-        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
-        const time = client.timeClient.getTime();
-        for await (const _ of time) {} // consume mocked stream completely
-        assert(spy.calledOnceWithExactly(ledgerId));
     });
 
     it('should correctly set the ledgerId of the NodeJsTimeClient (setTime)', (done) => {

--- a/test/client/LedgerClient.spec.ts
+++ b/test/client/LedgerClient.spec.ts
@@ -160,6 +160,12 @@ describe("DamlLedgerClient", () => {
         });
     });
 
+    it('should correctly set the ledgerId of the PackageService (listPackages -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.packageClient.listPackages();
+        assert(spy.calledOnceWithExactly(ledgerId));
+    });
+
     it('should correctly set the ledgerId of the PackageService (getPackage)', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
@@ -169,6 +175,12 @@ describe("DamlLedgerClient", () => {
                 done();
             });
         });
+    });
+
+    it('should correctly set the ledgerId of the PackageService (getPackage -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.packageClient.getPackage('');
+        assert(spy.calledOnceWithExactly(ledgerId));
     });
 
     it('should correctly set the ledgerId of the PackageService (getPackageStatus)', (done) => {
@@ -182,15 +194,28 @@ describe("DamlLedgerClient", () => {
         });
     });
 
+    it('should correctly set the ledgerId of the PackageService (getPackageStatus -- promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        await client.packageClient.getPackageStatus('');
+        assert(spy.calledOnceWithExactly(ledgerId));
+    });
+
     it('should correctly set the ledgerId of the LedgerConfigurationService', (done) => {
         DamlLedgerClient.connect({host: '0.0.0.0', port: port}, (error, client) => {
             expect(error).to.be.null;
-            const call = client!.ledgerConfigurationClient.getLedgerConfiguration()
+            const call = client!.ledgerConfigurationClient.getLedgerConfiguration();
             call.on('end', () => {
                 assert(spy.calledOnceWithExactly(ledgerId));
                 done();
             });
         });
+    });
+
+    it('should correctly set the ledgerId of the LedgerConfigurationService (promisified)', async () => {
+        const client = await DamlLedgerClient.connect({host: '0.0.0.0', port: port});
+        const changes = client.ledgerConfigurationClient.getLedgerConfiguration();
+        for await (const _ of changes) {} // consume mocked stream completely
+        assert(spy.calledOnceWithExactly(ledgerId));
     });
 
     it('should correctly set the ledgerId of the TransactionsClient (getLedgerEnd)', (done) => {

--- a/test/client/LedgerConfigurationClient.spec.ts
+++ b/test/client/LedgerConfigurationClient.spec.ts
@@ -3,16 +3,16 @@
 
 import {assert, expect} from 'chai';
 import * as sinon from 'sinon';
-import {LedgerConfigurationClient} from "../../src/client/LedgerConfigurationClient";
+import {NodeJsLedgerConfigurationClient} from "../../src/client/NodeJsLedgerConfigurationClient";
 import {GetLedgerConfigurationRequest as PbGetLedgerConfigurationRequest} from "../../src/generated/com/digitalasset/ledger/api/v1/ledger_configuration_service_pb";
 import {DummyLedgerConfigurationServiceClient} from "./DummyLedgerConfigurationServiceClient";
 
-describe('LedgerConfigurationClient', () => {
+describe('NodeJsLedgerConfigurationClient', () => {
 
     const ledgerId = 'cafebabe';
     const latestRequestSpy = sinon.spy();
     const dummy = new DummyLedgerConfigurationServiceClient(latestRequestSpy);
-    const client = new LedgerConfigurationClient(ledgerId, dummy);
+    const client = new NodeJsLedgerConfigurationClient(ledgerId, dummy);
 
     afterEach(() => {
         sinon.restore();

--- a/test/client/LedgerIdentityClient.spec.ts
+++ b/test/client/LedgerIdentityClient.spec.ts
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {assert, expect} from 'chai';
-import {LedgerIdentityClient} from "../../src/client/LedgerIdentityClient";
+import {NodeJsLedgerIdentityClient} from "../../src/client/NodeJsLedgerIdentityClient";
 import {DummyLedgerIdentityServiceClient} from "./DummyLedgerIdentityServiceClient";
 import * as sinon from "sinon";
 import {GetLedgerIdentityRequest as PbGetLedgerIdentityRequest} from "../../src/generated/com/digitalasset/ledger/api/v1/ledger_identity_service_pb";
 
-describe("LedgerIdentityClient", () => {
+describe("NodeJsLedgerIdentityClient", () => {
 
     const latestRequestSpy = sinon.spy();
     const dummy = new DummyLedgerIdentityServiceClient(latestRequestSpy);
-    const client = new LedgerIdentityClient(dummy);
+    const client = new NodeJsLedgerIdentityClient(dummy);
 
     afterEach(() => {
         sinon.restore();
@@ -26,6 +26,13 @@ describe("LedgerIdentityClient", () => {
             expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetLedgerIdentityRequest);
             done();
         });
+    });
+
+    it("should correctly send the request to the server (promisified)", async () => {
+        await client.getLedgerIdentity();
+        assert(latestRequestSpy.calledOnce, 'The latestRequestSpy has not been called exactly once');
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetLedgerIdentityRequest);
     });
 
 });

--- a/test/client/PackageClient.spec.ts
+++ b/test/client/PackageClient.spec.ts
@@ -24,7 +24,7 @@ describe("NodeJsPackageClient", () => {
         latestRequestSpy.resetHistory();
     });
 
-    it("should send the request with the correct ledger identifier", (done) => {
+    it("should send the request with the correct request and ledger identifier", (done) => {
         client.listPackages((error, _response) => {
             expect(error).to.be.null;
             assert(latestRequestSpy.calledOnce, 'The latestRequestSpy has not been called exactly once');
@@ -36,7 +36,16 @@ describe("NodeJsPackageClient", () => {
         });
     });
 
-    it("should send the package request with the correct package identifier", (done) => {
+    it("should send the request with the correct request and ledger identifier (promisified)", async () => {
+        await client.listPackages();
+        assert(latestRequestSpy.calledOnce, 'The latestRequestSpy has not been called exactly once');
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbListPackagesRequest);
+        const request = latestRequestSpy.lastCall.lastArg as PbListPackagesRequest;
+        expect(request.getLedgerId()).to.equal(ledgerId);
+    });
+
+    it("should send the package request with the correct request and package identifier", (done) => {
         client.getPackage('package-2', (error, _response) => {
             expect(error).to.be.null;
             assert(latestRequestSpy.calledOnce, 'The latestRequestSpy has not been called exactly once');
@@ -49,7 +58,17 @@ describe("NodeJsPackageClient", () => {
         });
     });
 
-    it("should send the package status request with the correct package identifier", (done) => {
+    it("should send the package request with the correct request and package identifier (promisified)", async () => {
+        await client.getPackage('package-2', );
+        assert(latestRequestSpy.calledOnce, 'The latestRequestSpy has not been called exactly once');
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetPackageRequest);
+        const request = latestRequestSpy.lastCall.lastArg as PbGetPackageRequest;
+        expect(request.getLedgerId()).to.equal(ledgerId);
+        expect(request.getPackageId()).to.equal('package-2');
+    });
+
+    it("should send the package status request with the correct request and package identifier", (done) => {
         client.getPackageStatus('package-2', (error, _response) => {
             expect(error).to.be.null;
             assert(latestRequestSpy.calledOnce, 'The latestRequestSpy has not been called exactly once');
@@ -60,6 +79,16 @@ describe("NodeJsPackageClient", () => {
             expect(request.getPackageId()).to.equal('package-2');
             done();
         });
+    });
+
+    it("should send the package status request with the correct request and package identifier (promisified)", async () => {
+        await client.getPackageStatus('package-2', );
+        assert(latestRequestSpy.calledOnce, 'The latestRequestSpy has not been called exactly once');
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetPackageStatusRequest);
+        const request = latestRequestSpy.lastCall.lastArg as PbGetPackageStatusRequest;
+        expect(request.getLedgerId()).to.equal(ledgerId);
+        expect(request.getPackageId()).to.equal('package-2');
     });
 
 });

--- a/test/client/PackageClient.spec.ts
+++ b/test/client/PackageClient.spec.ts
@@ -3,7 +3,7 @@
 
 import {assert, expect} from 'chai';
 import * as sinon from 'sinon';
-import {PackageClient} from "../../src/client/PackageClient";
+import {NodeJsPackageClient} from "../../src/client/NodeJsPackageClient";
 import {
     GetPackageRequest as PbGetPackageRequest,
     GetPackageStatusRequest as PbGetPackageStatusRequest,
@@ -11,13 +11,13 @@ import {
 } from "../../src/generated/com/digitalasset/ledger/api/v1/package_service_pb";
 import {DummyPackageServiceClient} from "./DummyPackageServiceClient";
 
-describe("PackageClient", () => {
+describe("NodeJsPackageClient", () => {
 
     const ledgerId = 'some-cool-id';
     const latestRequestSpy = sinon.spy();
 
     const dummy = new DummyPackageServiceClient(latestRequestSpy);
-    const client = new PackageClient(ledgerId, dummy);
+    const client = new NodeJsPackageClient(ledgerId, dummy);
 
     afterEach(() => {
         sinon.restore();

--- a/test/client/ResetClient.spec.ts
+++ b/test/client/ResetClient.spec.ts
@@ -3,17 +3,17 @@
 
 import {assert, expect} from 'chai';
 import * as sinon from 'sinon';
-import {ResetClient} from "../../src/client/ResetClient";
+import {NodeJsResetClient} from "../../src/client/NodeJsResetClient";
 import {ResetRequest as PbResetRequest} from "../../src/generated/com/digitalasset/ledger/api/v1/testing/reset_service_pb";
 import {DummyResetServiceClient} from "./DummyResetServiceClient";
 
-describe("ResetClient", () => {
+describe("NodeJsResetClient", () => {
 
     const ledgerId = 'cafebabe';
 
     const latestRequestSpy = sinon.spy();
     const dummy = new DummyResetServiceClient(latestRequestSpy);
-    const client = new ResetClient(ledgerId, dummy);
+    const client = new NodeJsResetClient(ledgerId, dummy);
 
     it("should pass the correct ledger identifier", (done) => {
         client.reset((error, _response) => {

--- a/test/client/ResetClient.spec.ts
+++ b/test/client/ResetClient.spec.ts
@@ -15,7 +15,12 @@ describe("NodeJsResetClient", () => {
     const dummy = new DummyResetServiceClient(latestRequestSpy);
     const client = new NodeJsResetClient(ledgerId, dummy);
 
-    it("should pass the correct ledger identifier", (done) => {
+    afterEach(() => {
+        sinon.restore();
+        latestRequestSpy.resetHistory();
+    });
+
+    it("should pass the correct request and ledger identifier", (done) => {
         client.reset((error, _response) => {
             expect(error).to.be.null;
             assert(latestRequestSpy.calledOnce, 'The latestRequestSpy has not been called exactly once');
@@ -25,6 +30,15 @@ describe("NodeJsResetClient", () => {
             expect(request.getLedgerId()).to.equal(ledgerId);
             done();
         });
+    });
+
+    it("should pass the correct request and ledger identifier (promisified)", async () => {
+        await client.reset();
+        assert(latestRequestSpy.calledOnce, 'The latestRequestSpy has not been called exactly once');
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbResetRequest);
+        const request = latestRequestSpy.lastCall.lastArg as PbResetRequest;
+        expect(request.getLedgerId()).to.equal(ledgerId);
     });
 
 });

--- a/test/client/TransactionClient.spec.ts
+++ b/test/client/TransactionClient.spec.ts
@@ -6,7 +6,7 @@ import * as sinon from 'sinon';
 import {GetTransactionsRequest} from "../../src/model/GetTransactionsRequest";
 import {GetTransactionByIdRequest} from "../../src/model/GetTransactionByIdRequest";
 import {GetTransactionByEventIdRequest} from "../../src/model/GetTransactionByEventIdRequest";
-import {TransactionClient} from "../../src/client/TransactionClient";
+import {NodeJsTransactionClient} from "../../src/client/NodeJsTransactionClient";
 import {ValidationTree} from "../../src/validation/Validation";
 import {LedgerOffsetBoundaryValue} from "../../src/model/LedgerOffset";
 import {JSONReporter} from "../../src/reporting/JSONReporter";
@@ -18,7 +18,7 @@ import {
 } from "../../src/generated/com/digitalasset/ledger/api/v1/transaction_service_pb";
 import {DummyTransactionServiceClient} from "./DummyTransactionServiceClient";
 
-describe('TransactionClient', () => {
+describe('NodeJsTransactionClient', () => {
 
     const transactionsRequest: GetTransactionsRequest = {
         begin: {
@@ -54,7 +54,7 @@ describe('TransactionClient', () => {
     const latestRequestSpy = sinon.spy();
     const ledgerId = 'deadbeef';
     const dummy = new DummyTransactionServiceClient(latestRequestSpy);
-    const client = new TransactionClient(ledgerId, dummy, JSONReporter);
+    const client = new NodeJsTransactionClient(ledgerId, dummy, JSONReporter);
 
     afterEach(() => {
         latestRequestSpy.resetHistory();
@@ -188,6 +188,19 @@ describe('TransactionClient', () => {
 
     });
 
+    it('should pass the requesting parties to the transaction lookup by event identifier endpoint (promisified)', async () => {
+
+        await client.getTransactionByEventId(transactionByEventIdRequest);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByEventIdRequest);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByEventIdRequest;
+        expect(spiedRequest.getRequestingPartiesList()).to.have.lengthOf(2);
+        expect(spiedRequest.getRequestingPartiesList()![0]).to.equal('barbara');
+        expect(spiedRequest.getRequestingPartiesList()![1]).to.equal('samuel');
+
+    });
+
     it('should pass the requesting parties to the flat transaction lookup by event identifier endpoint', (done) => {
 
         client.getFlatTransactionByEventId(transactionByEventIdRequest, (error, _response) => {
@@ -201,6 +214,19 @@ describe('TransactionClient', () => {
             expect(spiedRequest.getRequestingPartiesList()![1]).to.equal('samuel');
             done();
         });
+
+    });
+
+    it('should pass the requesting parties to the flat transaction lookup by event identifier endpoint (promisified)', async () => {
+
+        await client.getFlatTransactionByEventId(transactionByEventIdRequest);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByEventIdRequest);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByEventIdRequest;
+        expect(spiedRequest.getRequestingPartiesList()).to.have.lengthOf(2);
+        expect(spiedRequest.getRequestingPartiesList()![0]).to.equal('barbara');
+        expect(spiedRequest.getRequestingPartiesList()![1]).to.equal('samuel');
 
     });
 
@@ -218,6 +244,17 @@ describe('TransactionClient', () => {
 
     });
 
+    it('should pass the correct ledger identifier to the transaction lookup by event identifier endpoint (promisified)', async () => {
+
+        await client.getTransactionByEventId(transactionByEventIdRequest);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByEventIdRequest);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByEventIdRequest;
+        expect(spiedRequest.getLedgerId()).to.equal(ledgerId);
+
+    });
+
     it('should pass the correct ledger identifier to the flat transaction lookup by event identifier endpoint', (done) => {
 
         client.getFlatTransactionByEventId(transactionByEventIdRequest, (error, _response) => {
@@ -229,6 +266,17 @@ describe('TransactionClient', () => {
             expect(spiedRequest.getLedgerId()).to.equal(ledgerId);
             done();
         });
+
+    });
+
+    it('should pass the correct ledger identifier to the flat transaction lookup by event identifier endpoint (promisified)', async () => {
+
+        await client.getFlatTransactionByEventId(transactionByEventIdRequest);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByEventIdRequest);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByEventIdRequest;
+        expect(spiedRequest.getLedgerId()).to.equal(ledgerId);
 
     });
 
@@ -245,6 +293,20 @@ describe('TransactionClient', () => {
             expect(spiedRequest.getRequestingPartiesList()![1]).to.equal('ethan');
             done();
         });
+
+    });
+
+    it('should pass the requesting parties to the transaction lookup by transaction identifier endpoint (promisified)', async () => {
+
+        await client.getTransactionById(transactionByIdRequest);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByIdRequest);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByIdRequest;
+        expect(spiedRequest.getRequestingPartiesList()).to.have.lengthOf(2);
+        expect(spiedRequest.getRequestingPartiesList()![0]).to.equal('joel');
+        expect(spiedRequest.getRequestingPartiesList()![1]).to.equal('ethan');
+
     });
 
     it('should pass the requesting parties to the flat transaction lookup by transaction identifier endpoint', (done) => {
@@ -260,6 +322,20 @@ describe('TransactionClient', () => {
             expect(spiedRequest.getRequestingPartiesList()![1]).to.equal('ethan');
             done();
         });
+
+    });
+
+    it('should pass the requesting parties to the flat transaction lookup by transaction identifier endpoint (promisified)', async () => {
+
+        await client.getFlatTransactionById(transactionByIdRequest);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByIdRequest);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByIdRequest;
+        expect(spiedRequest.getRequestingPartiesList()).to.have.lengthOf(2);
+        expect(spiedRequest.getRequestingPartiesList()![0]).to.equal('joel');
+        expect(spiedRequest.getRequestingPartiesList()![1]).to.equal('ethan');
+
     });
 
     it('should pass the correct ledger identifier to the transaction lookup by transaction identifier', (done) => {
@@ -273,6 +349,17 @@ describe('TransactionClient', () => {
             expect(spiedRequest.getLedgerId()).to.equal(ledgerId);
             done();
         });
+
+    });
+
+    it('should pass the correct ledger identifier to the transaction lookup by transaction identifier (promisified)', async () => {
+
+        await client.getTransactionById(transactionByIdRequest);
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByIdRequest);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByIdRequest;
+        expect(spiedRequest.getLedgerId()).to.equal(ledgerId);
 
     });
 
@@ -290,6 +377,17 @@ describe('TransactionClient', () => {
 
     });
 
+    it('should pass the correct ledger identifier to the flat transaction lookup by transaction identifier (promisified)', async () => {
+
+        await client.getFlatTransactionById(transactionByIdRequest)
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetTransactionByIdRequest);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetTransactionByIdRequest;
+        expect(spiedRequest.getLedgerId()).to.equal(ledgerId);
+
+    });
+
     it('should pass the correct ledger identifier to the ledger end endpoint', (done) => {
 
         client.getLedgerEnd((error, _response) => {
@@ -304,135 +402,198 @@ describe('TransactionClient', () => {
 
     });
 
+    it('should pass the correct ledger identifier to the ledger end endpoint (promisified)', async () => {
+
+        await client.getLedgerEnd();
+        assert(latestRequestSpy.calledOnce);
+        expect(latestRequestSpy.lastCall.args).to.have.length(1);
+        expect(latestRequestSpy.lastCall.lastArg).to.be.an.instanceof(PbGetLedgerEndRequest);
+        const spiedRequest = latestRequestSpy.lastCall.lastArg as PbGetLedgerEndRequest;
+        expect(spiedRequest.getLedgerId()).to.equal(ledgerId);
+
+    });
+
+    const invalidRequestGetTxById = {
+        transactionId: 'some-tx-id',
+        requestingParties: 42
+    };
+
+    const expectedValidationTreeGetTxById: ValidationTree = {
+        errors: [],
+        children: {
+            transactionId: {
+                errors: [],
+                children: {}
+            },
+            requestingParties: {
+                errors: [{
+                    errorType: 'type-error',
+                    expectedType: 'Array<string>',
+                    actualType: 'number'
+                }],
+                children: {}
+            }
+        }
+    };
+
     it('should perform validation on the GetTransactionById endpoint', (done) => {
 
-        const invalidRequest = {
-            transactionId: 'some-tx-id',
-            requestingParties: 42
-        };
-
-        const expectedValidationTree: ValidationTree = {
-            errors: [],
-            children: {
-                transactionId: {
-                    errors: [],
-                    children: {}
-                },
-                requestingParties: {
-                    errors: [{
-                        errorType: 'type-error',
-                        expectedType: 'Array<string>',
-                        actualType: 'number'
-                    }],
-                    children: {}
-                }
-            }
-        };
-
-        client.getTransactionById(invalidRequest as any as GetTransactionByIdRequest, error => {
+        client.getTransactionById(invalidRequestGetTxById as unknown as GetTransactionByIdRequest, error => {
             expect(error).to.not.be.null;
-            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTree);
+            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTreeGetTxById);
             done();
         });
 
     });
+
+    it('should perform validation on the GetTransactionById endpoint (promisified)', async () => {
+
+        let errorThrown = false;
+        try {
+            await client.getTransactionById(invalidRequestGetTxById as unknown as GetTransactionByIdRequest);
+        } catch (error) {
+            expect(JSON.parse(error.message)).to.deep.equal(expectedValidationTreeGetTxById);
+            errorThrown = true;
+        }
+        assert(errorThrown, 'an error was expected but none has been thrown');
+
+    });
+
+    const invalidRequestGetFlatTxById = {
+        transactionId: 'some-tx-id',
+        requestingParties: 42
+    };
+
+    const expectedValidationTreeGetFlatTxById: ValidationTree = {
+        errors: [],
+        children: {
+            transactionId: {
+                errors: [],
+                children: {}
+            },
+            requestingParties: {
+                errors: [{
+                    errorType: 'type-error',
+                    expectedType: 'Array<string>',
+                    actualType: 'number'
+                }],
+                children: {}
+            }
+        }
+    };
 
     it('should perform validation on the GetFlatTransactionById endpoint', (done) => {
 
-        const invalidRequest = {
-            transactionId: 'some-tx-id',
-            requestingParties: 42
-        };
-
-        const expectedValidationTree: ValidationTree = {
-            errors: [],
-            children: {
-                transactionId: {
-                    errors: [],
-                    children: {}
-                },
-                requestingParties: {
-                    errors: [{
-                        errorType: 'type-error',
-                        expectedType: 'Array<string>',
-                        actualType: 'number'
-                    }],
-                    children: {}
-                }
-            }
-        };
-
-        client.getFlatTransactionById(invalidRequest as any as GetTransactionByIdRequest, error => {
+        client.getFlatTransactionById(invalidRequestGetFlatTxById as unknown as GetTransactionByIdRequest, error => {
             expect(error).to.not.be.null;
-            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTree);
+            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTreeGetFlatTxById);
             done();
         });
 
     });
+
+    it('should perform validation on the GetFlatTransactionById endpoint (promisified)', async () => {
+
+        let errorThrown = false;
+        try {
+            await client.getFlatTransactionById(invalidRequestGetFlatTxById as unknown as GetTransactionByIdRequest);
+        } catch (error) {
+            expect(JSON.parse(error.message)).to.deep.equal(expectedValidationTreeGetFlatTxById);
+            errorThrown = true;
+        }
+        assert(errorThrown, 'an error was expected but none has been thrown');
+
+    });
+
+    const invalidRequestGetTxByEvent = {
+        eventId: 'some-event-id',
+        requestingParties: 42
+    };
+
+    const expectedValidationTreeGetTxByEvent: ValidationTree = {
+        errors: [],
+        children: {
+            eventId: {
+                errors: [],
+                children: {}
+            },
+            requestingParties: {
+                errors: [{
+                    errorType: 'type-error',
+                    expectedType: 'Array<string>',
+                    actualType: 'number'
+                }],
+                children: {}
+            }
+        }
+    };
 
     it('should perform validation on the GetTransactionByEventId endpoint', (done) => {
 
-        const invalidRequest = {
-            eventId: 'some-event-id',
-            requestingParties: 42
-        };
-
-        const expectedValidationTree: ValidationTree = {
-            errors: [],
-            children: {
-                eventId: {
-                    errors: [],
-                    children: {}
-                },
-                requestingParties: {
-                    errors: [{
-                        errorType: 'type-error',
-                        expectedType: 'Array<string>',
-                        actualType: 'number'
-                    }],
-                    children: {}
-                }
-            }
-        };
-
-        client.getTransactionByEventId(invalidRequest as any as GetTransactionByEventIdRequest, error => {
+        client.getTransactionByEventId(invalidRequestGetTxByEvent as unknown as GetTransactionByEventIdRequest, error => {
             expect(error).to.not.be.null;
-            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTree);
+            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTreeGetTxByEvent);
             done();
         });
 
     });
 
+    it('should perform validation on the GetTransactionByEventId endpoint (promisified)', async () => {
+
+        let errorThrown = false;
+        try {
+            await client.getTransactionByEventId(invalidRequestGetTxByEvent as unknown as GetTransactionByEventIdRequest);
+        } catch (error) {
+            expect(JSON.parse(error.message)).to.deep.equal(expectedValidationTreeGetTxByEvent);
+            errorThrown = true;
+        }
+        assert(errorThrown, 'an error was expected but none has been thrown');
+
+    });
+
+    const invalidRequestGetFlatTxByEvent = {
+        eventId: 'some-event-id',
+        requestingParties: 42
+    };
+
+    const expectedValidationTreeGetFlatTxByEvent: ValidationTree = {
+        errors: [],
+        children: {
+            eventId: {
+                errors: [],
+                children: {}
+            },
+            requestingParties: {
+                errors: [{
+                    errorType: 'type-error',
+                    expectedType: 'Array<string>',
+                    actualType: 'number'
+                }],
+                children: {}
+            }
+        }
+    };
+
     it('should perform validation on the GetFlatTransactionByEventId endpoint', (done) => {
 
-        const invalidRequest = {
-            eventId: 'some-event-id',
-            requestingParties: 42
-        };
-
-        const expectedValidationTree: ValidationTree = {
-            errors: [],
-            children: {
-                eventId: {
-                    errors: [],
-                    children: {}
-                },
-                requestingParties: {
-                    errors: [{
-                        errorType: 'type-error',
-                        expectedType: 'Array<string>',
-                        actualType: 'number'
-                    }],
-                    children: {}
-                }
-            }
-        };
-
-        client.getFlatTransactionByEventId(invalidRequest as any as GetTransactionByEventIdRequest, error => {
+        client.getFlatTransactionByEventId(invalidRequestGetFlatTxByEvent as unknown as GetTransactionByEventIdRequest, error => {
             expect(error).to.not.be.null;
-            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTree);
+            expect(JSON.parse(error!.message)).to.deep.equal(expectedValidationTreeGetFlatTxByEvent);
             done();
         });
+
+    });
+
+    it('should perform validation on the GetFlatTransactionByEventId endpoint (promisified)', async () => {
+
+        let errorThrown = false;
+        try {
+            await client.getFlatTransactionByEventId(invalidRequestGetFlatTxByEvent as unknown as GetTransactionByEventIdRequest);
+        } catch (error) {
+            expect(JSON.parse(error.message)).to.deep.equal(expectedValidationTreeGetFlatTxByEvent);
+            errorThrown = true;
+        }
+        assert(errorThrown, 'an error was expected but none has been thrown');
 
     });
 


### PR DESCRIPTION
Closes #71 

This PR addresses #71 in two ways:
1. it creates interfaces around the exposed services so that the underlying access mechanism is decoupled from the implementation (this means that the code can be split in separate packages, with a reusable core that can, eventually, be used from the browser directly), and
2. it overloads the existing methods to return a promise when no callback is passed: this way, the existing code will continue working and the same, familiar methods can be re-used using `async`-`await`

The test code can be used to evaluate the proposed API and draw valuable comparisons in terms of usability.

![promisify-all-the-things](https://i.imgflip.com/346zzc.jpg)