### PR TITLE
Disable BlackDuck scan on CI for PR coming from forks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,4 +40,6 @@ steps:
   displayName: Blackduck security scan
   env:
     BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
+  # The BlackDuck token is not available from forks, hence we skip this step
+  condition: not(variables['System.PullRequest.IsFork'])
 


### PR DESCRIPTION
The token required to run BlackDuck scan is not available to forks which makes it impossible for PRs coming from forks to pass CI and be eventually merged. #75 is currently blocked because of this.

This PR tries to address the issue by disabling BlackDuck scans when running CI on PRs from forks.