### PR TITLE
Ship DAML-LF Archive 1.8 with the bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - add support for enum values from SDK 0.13.13 [#97](https://github.com/digital-asset/daml-js/issues/97)
 - add support for signatories and observers in created events from SDK 0.13.8 [#96](https://github.com/digital-asset/daml-js/issues/96)
 - add support for contract keys in created events from SDK 0.12.25 [#95](https://github.com/digital-asset/daml-js/issues/95)
+- add support for DAML-LF 1.8 (and earlier) [#98](https://github.com/digital-asset/daml-js/issues/98)
 
 ## [0.9.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - add support for signatories and observers in created events from SDK 0.13.8 [#96](https://github.com/digital-asset/daml-js/issues/96)
 - add support for contract keys in created events from SDK 0.12.25 [#95](https://github.com/digital-asset/daml-js/issues/95)
 - add support for DAML-LF 1.8 (and earlier) [#98](https://github.com/digital-asset/daml-js/issues/98)
+- the call to `getTransactionTrees` is now verbose by default (mirroring `getTransactions`) [#102](https://github.com/digital-asset/daml-js/issues/102)
 
 ## [0.9.0]
 ### Changed

--- a/grpc-codegen.sh
+++ b/grpc-codegen.sh
@@ -23,7 +23,7 @@ if [ ! -d "$PROTO_PATH" ]; then
     mkdir -p "$PROTO_PATH" && (
       cd "$PROTO_PATH"
       curl -s https://repo1.maven.org/maven2/com/digitalasset/ledger-api-protos/$SDK_VERSION/ledger-api-protos-$SDK_VERSION.tar.gz | tar xz --strip-components 2
-      curl -s https://digitalassetsdk.bintray.com/DigitalAssetSDK/com/digitalasset/daml-lf-1.6-archive-proto/"$SDK_VERSION"/daml-lf-1.6-archive-proto-"$SDK_VERSION".tar.gz | tar xz
+      curl -s https://digitalassetsdk.bintray.com/DigitalAssetSDK/com/digitalasset/daml-lf-1.8-archive-proto/"$SDK_VERSION"/daml-lf-1.8-archive-proto-"$SDK_VERSION".tar.gz | tar xz
       mkdir -p grpc/health/v1
       curl -s https://raw.githubusercontent.com/grpc/grpc/v"$GRPC_VERSION"/src/proto/grpc/health/v1/health.proto > grpc/health/v1/health.proto
       mkdir -p google/rpc
@@ -50,7 +50,7 @@ if [ ! -d "$OUT_PATH" ]; then
       --js_out="import_style=commonjs,binary:${OUT_PATH}" \
       --proto_path="${PROTO_PATH}" \
       --grpc_out="${OUT_PATH}" \
-      "${PROTO_PATH}"/com/digitalasset/daml_lf_1_6/*.proto
+      "${PROTO_PATH}"/com/digitalasset/daml_lf_1_8/*.proto
     grpc_tools_node_protoc \
       --plugin=protoc-gen-ts=`which protoc-gen-ts` \
       --proto_path="${PROTO_PATH}" \
@@ -64,7 +64,7 @@ if [ ! -d "$OUT_PATH" ]; then
       --plugin=protoc-gen-ts=`which protoc-gen-ts` \
       --proto_path="${PROTO_PATH}" \
       --ts_out="${OUT_PATH}" \
-      "${PROTO_PATH}"/com/digitalasset/daml_lf_1_6/*.proto
+      "${PROTO_PATH}"/com/digitalasset/daml_lf_1_8/*.proto
 fi
 
 if [ ! -d "$TEST_OUT_PATH" ]; then

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export {
     NodeJsPackageManagementClient as PackageManagementClient
 };
 
-import * as lf from './generated/com/digitalasset/daml_lf_1_6/daml_lf_pb';
+import * as lf from './generated/com/digitalasset/daml_lf_1_8/daml_lf_pb';
 export {lf};
 
 import {Any} from './model/Any';

--- a/test/integration/IntegrationTests.spec.ts
+++ b/test/integration/IntegrationTests.spec.ts
@@ -377,7 +377,6 @@ describe('Template identifier retrieval', () => {
         const archive = lf.ArchivePayload.deserializeBinary(archivePayload as unknown as Uint8Array).getDamlLf1()!;
         for (const damlModule of archive.getModulesList()) {
             if (damlModule.hasNameDname()) {
-                expect(damlModule.hasNameDname()).to.be.true;
                 const moduleName = damlModule.getNameDname()!.getSegmentsList().join('.');
                 for (const template of damlModule.getTemplatesList()) {
                     expect(template.hasTyconDname()).to.be.true;
@@ -385,7 +384,6 @@ describe('Template identifier retrieval', () => {
                     templateNames.push(`${moduleName}:${templateName}`);
                 }
             } else if (damlModule.hasNameInternedDname()) {
-                expect(damlModule.hasNameInternedDname()).to.be.true;
                 const internedDottedNames = archive.getInternedDottedNamesList();
                 const internedStrings = archive.getInternedStringsList();
                 const i = damlModule.getNameInternedDname();

--- a/test/integration/IntegrationTests.spec.ts
+++ b/test/integration/IntegrationTests.spec.ts
@@ -410,7 +410,6 @@ describe('Template identifier retrieval', () => {
                 expect(response!.packageIds).to.contain(packageId).and.to.contain(tokenPackageId);
                 client.packageClient.getPackage(packageId, (error, response) => {
                     expect(error).to.be.null;
-                    console.log(JSON.stringify(getTemplateIds(response!.archivePayload)));
                     expect(getTemplateIds(response!.archivePayload).sort()).to.deep.equal(['IntegrationTests:Ping', 'IntegrationTests:Pong', 'IntegrationTests:ContractKeys'].sort());
                     client.packageClient.getPackage(tokenPackageId, (error, response) => {
                         expect(error).to.be.null;

--- a/test/integration/src/uploadDar/daml.yaml
+++ b/test/integration/src/uploadDar/daml.yaml
@@ -10,3 +10,5 @@ version: '0.0.0'
 dependencies:
   - daml-prim
   - daml-stdlib
+build-options:
+  - --target=1.8

--- a/test/integration/src/uploadDar/daml/CreateToken.daml
+++ b/test/integration/src/uploadDar/daml/CreateToken.daml
@@ -1,8 +1,6 @@
 -- Copyright (c) 2019, The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
-
 module CreateToken where
 
 template Token


### PR DESCRIPTION
Also adds an integration test for template identifier lookup.

Closes #98