### PR TITLE
Switch from "grpc" to "@grpc/grpc-js"

### DIFF
--- a/grpc-codegen.sh
+++ b/grpc-codegen.sh
@@ -35,25 +35,23 @@ fi
 if [ ! -d "$OUT_PATH" ]; then
     mkdir -p "$OUT_PATH"
     grpc_tools_node_protoc \
-      --plugin="protoc-gen-grpc=`which grpc_tools_node_protoc_plugin`" \
       --js_out="import_style=commonjs,binary:${OUT_PATH}" \
       --proto_path="${PROTO_PATH}" \
-      --grpc_out="${OUT_PATH}" \
+      --grpc_out="generate_package_definition:${OUT_PATH}" \
       "${PROTO_PATH}"/com/daml/ledger/api/v1/*.proto \
       "${PROTO_PATH}"/com/daml/ledger/api/v1/admin/*.proto \
       "${PROTO_PATH}"/com/daml/ledger/api/v1/testing/*.proto \
       "${PROTO_PATH}"/google/rpc/*.proto \
       "${PROTO_PATH}"/grpc/health/v1/*.proto
     grpc_tools_node_protoc \
-      --plugin="protoc-gen-grpc=`which grpc_tools_node_protoc_plugin`" \
       --js_out="import_style=commonjs,binary:${OUT_PATH}" \
       --proto_path="${PROTO_PATH}" \
-      --grpc_out="${OUT_PATH}" \
+      --grpc_out="generate_package_definition:${OUT_PATH}" \
       "${PROTO_PATH}"/com/digitalasset/daml_lf_1_8/*.proto
     grpc_tools_node_protoc \
       --plugin=protoc-gen-ts=`which protoc-gen-ts` \
       --proto_path="${PROTO_PATH}" \
-      --ts_out="${OUT_PATH}" \
+      --ts_out="generate_package_definition:${OUT_PATH}" \
       "${PROTO_PATH}"/com/daml/ledger/api/v1/*.proto \
       "${PROTO_PATH}"/com/daml/ledger/api/v1/admin/*.proto \
       "${PROTO_PATH}"/com/daml/ledger/api/v1/testing/*.proto \
@@ -62,21 +60,20 @@ if [ ! -d "$OUT_PATH" ]; then
     grpc_tools_node_protoc \
       --plugin=protoc-gen-ts=`which protoc-gen-ts` \
       --proto_path="${PROTO_PATH}" \
-      --ts_out="${OUT_PATH}" \
+      --ts_out="generate_package_definition:${OUT_PATH}" \
       "${PROTO_PATH}"/com/digitalasset/daml_lf_1_8/*.proto
 fi
 
 if [ ! -d "$TEST_OUT_PATH" ]; then
     mkdir -p "$TEST_OUT_PATH"
     grpc_tools_node_protoc \
-      --plugin="protoc-gen-grpc=`which grpc_tools_node_protoc_plugin`" \
       --js_out="import_style=commonjs,binary:${TEST_OUT_PATH}" \
       --proto_path="${PROTO_PATH}" \
-      --grpc_out="${TEST_OUT_PATH}" \
+      --grpc_out="generate_package_definition:${TEST_OUT_PATH}" \
       "${PROTO_PATH}"/grpc/reflection/v1alpha/reflection.proto
     grpc_tools_node_protoc \
       --plugin=protoc-gen-ts=`which protoc-gen-ts` \
       --proto_path="${PROTO_PATH}" \
-      --ts_out="${TEST_OUT_PATH}" \
+      --ts_out="generate_package_definition:${TEST_OUT_PATH}" \
       "${PROTO_PATH}"/grpc/reflection/v1alpha/reflection.proto
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@grpc/grpc-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.1.3.tgz",
+      "integrity": "sha512-HtOsk2YUofBcm1GkPqGzb6pwHhv+74eC2CUO229USIDKRtg30ycbZmqC+HdNtY3nHqoc9IgcRlntFgopyQoYCA==",
+      "requires": {
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -113,22 +128,6 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
-    "@types/bytebuffer": {
-      "version": "5.0.41",
-      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.41.tgz",
-      "integrity": "sha512-Mdrv4YcaHvpkx25ksqqFaezktx3yZRcd51GZY0rY/9avyaqZdiT/GiWRhfrJhMpgzXqTOSHgGvsumGxJFNiZZA==",
-      "requires": {
-        "@types/long": "*",
-        "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.0.27",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-          "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
-        }
-      }
-    },
     "@types/chai": {
       "version": "4.2.12",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
@@ -150,7 +149,8 @@
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
     },
     "@types/mocha": {
       "version": "8.0.1",
@@ -188,7 +188,8 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "ansi-bgblack": {
       "version": "0.1.1",
@@ -417,7 +418,8 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-reset": {
       "version": "0.1.1",
@@ -493,12 +495,14 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -574,15 +578,6 @@
         "is-string": "^1.0.4"
       }
     },
-    "ascli": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
-      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-      "requires": {
-        "colour": "~0.7.1",
-        "optjs": "~3.2.2"
-      }
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -613,7 +608,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -640,6 +636,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -675,14 +672,6 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "bytebuffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
-      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
-      "requires": {
-        "long": "~3"
-      }
-    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -699,11 +688,6 @@
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
       }
-    },
-    "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
     "chai": {
       "version": "4.2.0",
@@ -825,7 +809,8 @@
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -850,20 +835,11 @@
         }
       }
     },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -890,11 +866,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "colour": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -904,7 +875,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-with-sourcemaps": {
       "version": "1.1.0",
@@ -918,7 +890,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -929,7 +902,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "create-frame": {
       "version": "1.0.0",
@@ -984,6 +958,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -991,7 +966,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -1011,7 +987,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "default-compare": {
       "version": "1.0.0",
@@ -1082,12 +1059,14 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
     },
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true
     },
     "diff": {
       "version": "4.0.2",
@@ -1371,6 +1350,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
       "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dev": true,
       "requires": {
         "minipass": "^2.6.0"
       }
@@ -1378,7 +1358,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.1.3",
@@ -1397,6 +1378,7 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -1466,6 +1448,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1500,32 +1483,6 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
-    },
-    "grpc": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.3.tgz",
-      "integrity": "sha512-EDemzuZTfhM0hgrXqC4PtR76O3t+hTIYJYR5vgiW0yt2WJqo4mhxUqZUirzUQz34Psz7dbLp38C6Cl7Ij2vXRQ==",
-      "requires": {
-        "@types/bytebuffer": "^5.0.40",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.clone": "^4.5.0",
-        "nan": "^2.13.2",
-        "node-pre-gyp": "^0.15.0",
-        "protobufjs": "^5.0.3"
-      },
-      "dependencies": {
-        "protobufjs": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
-          "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
-          "requires": {
-            "ascli": "~1",
-            "bytebuffer": "~5",
-            "glob": "^7.0.5",
-            "yargs": "^3.10.0"
-          }
-        }
-      }
     },
     "grpc-tools": {
       "version": "1.9.1",
@@ -1731,7 +1688,8 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -1845,6 +1803,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -1853,6 +1812,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
       "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -1861,6 +1821,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1875,23 +1836,20 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -2010,6 +1968,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -2127,7 +2086,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -2215,14 +2175,6 @@
       "integrity": "sha1-iAy4qrJWAmOC4C9T7AiWgqdMW2o=",
       "dev": true
     },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -2243,16 +2195,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
-    "lodash.clone": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -2322,11 +2264,6 @@
         "isobject": "^3.0.0",
         "log-utils": "^0.2.1"
       }
-    },
-    "long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "lunr": {
       "version": "2.3.8",
@@ -2446,6 +2383,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2453,12 +2391,14 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minipass": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -2468,6 +2408,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
       "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dev": true,
       "requires": {
         "minipass": "^2.9.0"
       }
@@ -2497,6 +2438,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -2717,12 +2659,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -2807,6 +2745,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
       "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
+      "dev": true,
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -2836,6 +2775,7 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
       "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
+      "dev": true,
       "requires": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.3",
@@ -2853,6 +2793,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
       "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "dev": true,
       "requires": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -2868,6 +2809,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
       "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "dev": true,
       "requires": {
         "npm-normalize-package-bin": "^1.0.1"
       }
@@ -2875,12 +2817,14 @@
     "npm-normalize-package-bin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "dev": true
     },
     "npm-packlist": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
       "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "dev": true,
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -2891,6 +2835,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -2901,12 +2846,14 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -2985,37 +2932,28 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
     },
-    "optjs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
-    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "^1.0.0"
-      }
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -3060,7 +2998,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -3106,7 +3045,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -3175,6 +3115,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -3192,6 +3133,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3330,6 +3272,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -3337,7 +3280,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -3351,12 +3295,14 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "self-closing-tags": {
       "version": "1.0.1",
@@ -3367,7 +3313,8 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "4.0.0",
@@ -3381,7 +3328,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-getter": {
       "version": "0.1.0",
@@ -3418,7 +3366,8 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
     },
     "sinon": {
       "version": "9.0.2",
@@ -3610,6 +3559,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -3640,6 +3590,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -3648,6 +3599,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -3655,7 +3607,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "striptags": {
       "version": "3.1.1",
@@ -3690,6 +3643,7 @@
       "version": "4.4.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
       "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -4029,7 +3983,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "8.3.0",
@@ -4062,14 +4017,10 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
-    },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -4083,19 +4034,11 @@
       "integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==",
       "dev": true
     },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",
@@ -4103,29 +4046,11 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "yargs": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-      "requires": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
-      }
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "yargs-parser": {
       "version": "18.1.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/digital-asset/daml-js#readme",
   "dependencies": {
     "google-protobuf": "^3.12.4",
-    "grpc": "^1.24.3"
+    "@grpc/grpc-js": "^1.1.3"
   },
   "engines": {
     "node": ">=10.0.0 <13.0.0"

--- a/src/call/ClientCancellableCall.ts
+++ b/src/call/ClientCancellableCall.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ClientUnaryCall} from 'grpc';
+import {ClientUnaryCall} from '@grpc/grpc-js';
 
 export class ClientCancellableCall {
 

--- a/src/call/ClientReadableObjectStream.ts
+++ b/src/call/ClientReadableObjectStream.ts
@@ -3,7 +3,7 @@
 
 import {Readable, ReadableOptions} from 'stream';
 import {Codec} from '../codec/Codec';
-import {ClientReadableStream} from 'grpc';
+import {ClientReadableStream} from '@grpc/grpc-js';
 import {Deserializer} from "./Deserializer";
 
 /**

--- a/src/client/DamlLedgerClient.ts
+++ b/src/client/DamlLedgerClient.ts
@@ -1,50 +1,50 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChannelCredentials, credentials} from 'grpc';
+import { ChannelCredentials, credentials, makeClientConstructor } from '@grpc/grpc-js';
 
-import {Callback, forward} from '../util/Callback';
-import {LedgerClient, LedgerClientOptions} from "./LedgerClient";
-import {HumanReadableReporter} from "../reporting/HumanReadableReporter";
-import {ActiveContractsClient} from "./ActiveContractsClient";
-import {CommandClient} from "./CommandClient";
-import {ValidationReporter} from "../reporting/ValidationReporter";
-import {CommandCompletionClient} from "./CommandCompletionClient";
-import {NodeJsResetClient} from "./NodeJsResetClient";
-import {TransactionClient} from "./TransactionClient";
-import {TimeClient} from "./TimeClient";
-import {LedgerConfigurationClient} from "./LedgerConfigurationClient";
-import {NodeJsPackageClient} from "./NodeJsPackageClient";
-import {NodeJsLedgerIdentityClient} from "./NodeJsLedgerIdentityClient";
-import {NodeJsCommandSubmissionClient} from "./NodeJsCommandSubmissionClient";
-import {NodeJsPartyManagementClient} from "./NodeJsPartyManagementClient";
-import {NodeJsPackageManagementClient} from "./NodeJsPackageManagementClient";
-import {LedgerIdentityServiceClient} from "../generated/com/daml/ledger/api/v1/ledger_identity_service_grpc_pb";
-import {PartyManagementServiceClient} from "../generated/com/daml/ledger/api/v1/admin/party_management_service_grpc_pb";
-import {PackageManagementServiceClient} from "../generated/com/daml/ledger/api/v1/admin/package_management_service_grpc_pb";
-import {GetLedgerIdentityRequest} from "../generated/com/daml/ledger/api/v1/ledger_identity_service_pb";
-import {ActiveContractsServiceClient} from "../generated/com/daml/ledger/api/v1/active_contracts_service_grpc_pb";
-import {CommandServiceClient} from "../generated/com/daml/ledger/api/v1/command_service_grpc_pb";
-import {CommandCompletionServiceClient} from "../generated/com/daml/ledger/api/v1/command_completion_service_grpc_pb";
-import {CommandSubmissionServiceClient} from "../generated/com/daml/ledger/api/v1/command_submission_service_grpc_pb";
-import {PackageServiceClient} from "../generated/com/daml/ledger/api/v1/package_service_grpc_pb";
-import {LedgerConfigurationServiceClient} from "../generated/com/daml/ledger/api/v1/ledger_configuration_service_grpc_pb";
-import {TimeServiceClient} from "../generated/com/daml/ledger/api/v1/testing/time_service_grpc_pb";
-import {TransactionServiceClient} from "../generated/com/daml/ledger/api/v1/transaction_service_grpc_pb";
-import {ResetServiceClient} from "../generated/com/daml/ledger/api/v1/testing/reset_service_grpc_pb";
-import {NodeJsCommandClient} from "./NodeJsCommandClient";
-import {NodeJsActiveContractsClient} from "./NodeJsActiveContractsClient";
-import {NodeJsCommandCompletionClient} from "./NodeJsCommandCompletionClient";
-import {CommandSubmissionClient} from "./CommandSubmissionClient";
-import {NodeJsLedgerConfigurationClient} from "./NodeJsLedgerConfigurationClient";
-import {LedgerIdentityClient} from "./LedgerIdentityClient";
-import {PackageClient} from "./PackageClient";
-import {promisify} from "util";
-import {ResetClient} from "./ResetClient";
-import {NodeJsTimeClient} from "./NodeJsTimeClient";
-import {NodeJsTransactionClient} from "./NodeJsTransactionClient";
-import {PartyManagementClient} from './PartyManagementClient';
-import {PackageManagementClient} from './PackageManagementClient';
+import { Callback, forward } from '../util/Callback';
+import { LedgerClient, LedgerClientOptions } from "./LedgerClient";
+import { HumanReadableReporter } from "../reporting/HumanReadableReporter";
+import { ActiveContractsClient } from "./ActiveContractsClient";
+import { CommandClient } from "./CommandClient";
+import { ValidationReporter } from "../reporting/ValidationReporter";
+import { CommandCompletionClient } from "./CommandCompletionClient";
+import { NodeJsResetClient } from "./NodeJsResetClient";
+import { TransactionClient } from "./TransactionClient";
+import { TimeClient } from "./TimeClient";
+import { LedgerConfigurationClient } from "./LedgerConfigurationClient";
+import { NodeJsPackageClient } from "./NodeJsPackageClient";
+import { NodeJsLedgerIdentityClient } from "./NodeJsLedgerIdentityClient";
+import { NodeJsCommandSubmissionClient } from "./NodeJsCommandSubmissionClient";
+import { NodeJsPartyManagementClient } from "./NodeJsPartyManagementClient";
+import { NodeJsPackageManagementClient } from "./NodeJsPackageManagementClient";
+import * as ledgerIdentityService from "../generated/com/daml/ledger/api/v1/ledger_identity_service_grpc_pb";
+import * as partyManagementService from "../generated/com/daml/ledger/api/v1/admin/party_management_service_grpc_pb";
+import * as packageManagementService from "../generated/com/daml/ledger/api/v1/admin/package_management_service_grpc_pb";
+import { GetLedgerIdentityRequest } from "../generated/com/daml/ledger/api/v1/ledger_identity_service_pb";
+import * as activeContractsService from "../generated/com/daml/ledger/api/v1/active_contracts_service_grpc_pb";
+import * as commandService from "../generated/com/daml/ledger/api/v1/command_service_grpc_pb";
+import * as commandCompletionService from "../generated/com/daml/ledger/api/v1/command_completion_service_grpc_pb";
+import * as commandSubmissionService from "../generated/com/daml/ledger/api/v1/command_submission_service_grpc_pb";
+import * as packageService from "../generated/com/daml/ledger/api/v1/package_service_grpc_pb";
+import * as ledgerConfigurationService from "../generated/com/daml/ledger/api/v1/ledger_configuration_service_grpc_pb";
+import * as timeService from "../generated/com/daml/ledger/api/v1/testing/time_service_grpc_pb";
+import * as transactionService from "../generated/com/daml/ledger/api/v1/transaction_service_grpc_pb";
+import * as resetService from "../generated/com/daml/ledger/api/v1/testing/reset_service_grpc_pb";
+import { NodeJsCommandClient } from "./NodeJsCommandClient";
+import { NodeJsActiveContractsClient } from "./NodeJsActiveContractsClient";
+import { NodeJsCommandCompletionClient } from "./NodeJsCommandCompletionClient";
+import { CommandSubmissionClient } from "./CommandSubmissionClient";
+import { NodeJsLedgerConfigurationClient } from "./NodeJsLedgerConfigurationClient";
+import { LedgerIdentityClient } from "./LedgerIdentityClient";
+import { PackageClient } from "./PackageClient";
+import { promisify } from "util";
+import { ResetClient } from "./ResetClient";
+import { NodeJsTimeClient } from "./NodeJsTimeClient";
+import { NodeJsTransactionClient } from "./NodeJsTransactionClient";
+import { PartyManagementClient } from './PartyManagementClient';
+import { PackageManagementClient } from './PackageManagementClient';
 
 /**
  * A {@link LedgerClient} implementation that connects to an existing Ledger and provides clients to query it. To use the {@link DamlLedgerClient}
@@ -66,6 +66,33 @@ export class DamlLedgerClient implements LedgerClient {
     private readonly _partyManagementClient: PartyManagementClient;
     private readonly _packageManagementClient: PackageManagementClient;
 
+    private static readonly LedgerIdentityServiceClient =
+        makeClientConstructor((ledgerIdentityService as any)['com.daml.ledger.api.v1.LedgerIdentityService'], 'LedgerIdentityService');
+    private static readonly ActiveContractsServiceClient =
+        makeClientConstructor((activeContractsService as any)['com.daml.ledger.api.v1.ActiveContractsService'], 'ActiveContractsService');
+    private static readonly CommandServiceClient =
+        makeClientConstructor((commandService as any)['com.daml.ledger.api.v1.CommandService'], 'CommandService');
+    private static readonly CommandCompletionServiceClient =
+        makeClientConstructor((commandCompletionService as any)['com.daml.ledger.api.v1.CommandCompletionService'], 'CommandCompletionService');
+    private static readonly CommandSubmissionServiceClient =
+        makeClientConstructor((commandSubmissionService as any)['com.daml.ledger.api.v1.CommandSubmissionService'], 'CommandSubmissionService');
+    private static readonly PackageServiceClient =
+        makeClientConstructor((packageService as any)['com.daml.ledger.api.v1.PackageService'], 'PackageService');
+    private static readonly LedgerConfigurationServiceClient =
+        makeClientConstructor((ledgerConfigurationService as any)['com.daml.ledger.api.v1.LedgerConfigurationService'], 'LedgerConfigurationService');
+    private static readonly TimeServiceClient =
+        makeClientConstructor((timeService as any)['com.daml.ledger.api.v1.testing.TimeService'], 'TimeService');
+    private static readonly TransactionServiceClient =
+        makeClientConstructor((transactionService as any)['com.daml.ledger.api.v1.TransactionService'], 'TransactionService');
+    private static readonly ResetServiceClient =
+        makeClientConstructor((resetService as any)['com.daml.ledger.api.v1.testing.ResetService'], 'ResetService');
+    private static readonly PartyManagementServiceClient =
+        makeClientConstructor((partyManagementService as any)['com.daml.ledger.api.v1.admin.PartyManagementService'], 'PartyManagementService');
+    private static readonly PackageManagementServiceClient =
+        makeClientConstructor((packageManagementService as any)['com.daml.ledger.api.v1.admin.PackageManagementService'], 'PackageManagementService');
+
+
+
     private constructor(
         ledgerId: string,
         address: string,
@@ -76,56 +103,57 @@ export class DamlLedgerClient implements LedgerClient {
         this.ledgerId = ledgerId;
         this._activeContractsClient = new NodeJsActiveContractsClient(
             ledgerId,
-            new ActiveContractsServiceClient(address, credentials, grpcOptions),
+            new DamlLedgerClient.ActiveContractsServiceClient
+                (address, credentials, grpcOptions) as unknown as activeContractsService.ActiveContractsServiceClient,
             reporter
         );
         this._commandClient = new NodeJsCommandClient(
             ledgerId,
-            new CommandServiceClient(address, credentials, grpcOptions),
+            new DamlLedgerClient.CommandServiceClient(address, credentials, grpcOptions) as unknown as commandService.CommandServiceClient,
             reporter
         );
         this._commandCompletionClient = new NodeJsCommandCompletionClient(
             ledgerId,
-            new CommandCompletionServiceClient(address, credentials, grpcOptions),
+            new DamlLedgerClient.CommandCompletionServiceClient(address, credentials, grpcOptions) as unknown as commandCompletionService.CommandCompletionServiceClient,
             reporter
         );
         this._commandSubmissionClient = new NodeJsCommandSubmissionClient(
             ledgerId,
-            new CommandSubmissionServiceClient(address, credentials, grpcOptions),
+            new DamlLedgerClient.CommandSubmissionServiceClient(address, credentials, grpcOptions) as unknown as commandSubmissionService.CommandSubmissionServiceClient,
             reporter
         );
         this._ledgerIdentityClient = new NodeJsLedgerIdentityClient(
-            new LedgerIdentityServiceClient(address, credentials, grpcOptions)
+            new DamlLedgerClient.LedgerIdentityServiceClient(address, credentials, grpcOptions) as unknown as ledgerIdentityService.LedgerIdentityServiceClient
         );
         this._packageClient = new NodeJsPackageClient(
             ledgerId,
-            new PackageServiceClient(address, credentials, grpcOptions)
+            new DamlLedgerClient.PackageServiceClient(address, credentials, grpcOptions) as unknown as packageService.PackageServiceClient
         );
         this._ledgerConfigurationClient = new NodeJsLedgerConfigurationClient(
             ledgerId,
-            new LedgerConfigurationServiceClient(address, credentials, grpcOptions)
+            new DamlLedgerClient.LedgerConfigurationServiceClient(address, credentials, grpcOptions) as unknown as ledgerConfigurationService.LedgerConfigurationServiceClient
         );
         this._timeClient = new NodeJsTimeClient(
             ledgerId,
-            new TimeServiceClient(address, credentials, grpcOptions),
+            new DamlLedgerClient.TimeServiceClient(address, credentials, grpcOptions) as unknown as timeService.TimeServiceClient,
             reporter
         );
         this._transactionClient = new NodeJsTransactionClient(
             ledgerId,
-            new TransactionServiceClient(address, credentials, grpcOptions),
+            new DamlLedgerClient.TransactionServiceClient(address, credentials, grpcOptions) as unknown as transactionService.TransactionServiceClient,
             reporter
         );
         this._resetClient = new NodeJsResetClient(
             ledgerId,
-            new ResetServiceClient(address, credentials, grpcOptions)
+            new DamlLedgerClient.ResetServiceClient(address, credentials, grpcOptions) as unknown as resetService.ResetServiceClient,
         );
         this._partyManagementClient = new NodeJsPartyManagementClient(
-            new PartyManagementServiceClient(address, credentials, grpcOptions),
+            new DamlLedgerClient.PartyManagementServiceClient(address, credentials, grpcOptions) as unknown as partyManagementService.PartyManagementServiceClient,
             reporter
         );
 
         this._packageManagementClient = new NodeJsPackageManagementClient(
-            new PackageManagementServiceClient(address, credentials, grpcOptions),
+            new DamlLedgerClient.PackageManagementServiceClient(address, credentials, grpcOptions) as unknown as packageManagementService.PackageManagementServiceClient,
             reporter
         )
     }
@@ -170,11 +198,11 @@ export class DamlLedgerClient implements LedgerClient {
         return this._resetClient;
     }
 
-    get partyManagementClient(): PartyManagementClient{
+    get partyManagementClient(): PartyManagementClient {
         return this._partyManagementClient;
     }
 
-    get packageManagementClient(): PackageManagementClient{
+    get packageManagementClient(): PackageManagementClient {
         return this._packageManagementClient;
     }
 
@@ -204,7 +232,7 @@ export class DamlLedgerClient implements LedgerClient {
 
         const reporter = options.reporter || HumanReadableReporter;
         const address = `${options.host}:${options.port}`;
-        const client = new LedgerIdentityServiceClient(address, creds);
+        const client = new DamlLedgerClient.LedgerIdentityServiceClient(address, creds) as unknown as ledgerIdentityService.LedgerIdentityServiceClient;
 
         client.getLedgerIdentity(
             new GetLedgerIdentityRequest(),

--- a/test/call/DummyClientReadableStream.ts
+++ b/test/call/DummyClientReadableStream.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 import {Readable} from 'stream';
 
 export class DummyClientReadableStream<T> extends Readable {
@@ -12,7 +12,7 @@ export class DummyClientReadableStream<T> extends Readable {
         this.iterator = items[Symbol.iterator]();
     }
 
-    public static empty(): grpc.ClientReadableStream<never> {
+    public static empty(): DummyClientReadableStream<any> {
         return new DummyClientReadableStream([]);
     }
 
@@ -47,5 +47,9 @@ export class DummyClientReadableStream<T> extends Readable {
      */
     getPeer(): string {
         throw new Error('MOCK!');
+    }
+
+    deserialize(_: Buffer): never {
+        throw new Error('Mock!');
     }
 }

--- a/test/call/DummyClientUnaryCall.ts
+++ b/test/call/DummyClientUnaryCall.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 
 export class DummyClientUnaryCall {
     public static Instance: grpc.ClientUnaryCall = new DummyClientUnaryCall() as grpc.ClientUnaryCall;

--- a/test/call/EndToEndSSL.spec.ts
+++ b/test/call/EndToEndSSL.spec.ts
@@ -3,7 +3,7 @@
 
 import {expect} from 'chai';
 import * as sinon from 'sinon';
-import {ServerCredentials} from 'grpc';
+import {ServerCredentials} from '@grpc/grpc-js';
 import {ClientCertChain, ClientPrivateKey, RootCertChain, ServerCertChain, ServerPrivateKey} from '../ssl'
 import {DamlLedgerClient} from "../../src";
 import {DummyServer} from "../client/DummyServer";
@@ -18,10 +18,18 @@ describe("End-to-end SSL support", () => {
     }], true);
 
     const server = new DummyServer(ledgerId, sinon.spy());
-    const port = server.bind('localhost:0', serverCredentials);
+    let port: any = undefined;
 
-    before(() => {
-        server.start();
+
+    before((done) => {
+        server.bindAsync('localhost:0', serverCredentials, (err, actualPort) => {
+            if (err) {
+                return done(err);
+            }
+            port = actualPort;
+            server.start();
+            done();
+        });
     });
 
     after(() => {

--- a/test/call/EndToEndStream.spec.ts
+++ b/test/call/EndToEndStream.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ServerCredentials} from 'grpc';
+import {ServerCredentials} from '@grpc/grpc-js';
 import {expect} from 'chai';
 import * as sinon from 'sinon';
 import {DamlLedgerClient} from "../../src/client/DamlLedgerClient";
@@ -12,10 +12,17 @@ describe('End-to-end stream', () => {
     const ledgerId = 'cafebabe';
 
     const server = new DummyServer(ledgerId, sinon.spy());
-    const port = server.bind('0.0.0.0:0', ServerCredentials.createInsecure());
+    let port: any = undefined;
 
-    before(() => {
-        server.start();
+    before((done) => {
+        server.bindAsync('0.0.0.0:0', ServerCredentials.createInsecure(), (err, actualPort) => {
+            if (err) {
+                return done(err);
+            }
+            port = actualPort;
+            server.start();
+            done();
+        });
     });
 
     after(() => {

--- a/test/client/DummyActiveContractsServiceClient.ts
+++ b/test/client/DummyActiveContractsServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ClientReadableStream} from 'grpc';
+import {ClientReadableStream} from '@grpc/grpc-js';
 import {SinonSpy} from 'sinon';
 import {IActiveContractsServiceClient} from "../../src/generated/com/daml/ledger/api/v1/active_contracts_service_grpc_pb";
 import {

--- a/test/client/DummyCommandCompletionServiceClient.ts
+++ b/test/client/DummyCommandCompletionServiceClient.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as sinon from 'sinon';
-import {CallOptions, ClientReadableStream, ClientUnaryCall, Metadata} from 'grpc';
+import {CallOptions, ClientReadableStream, ClientUnaryCall, Metadata, ServiceError} from '@grpc/grpc-js';
 import {ICommandCompletionServiceClient} from "../../src/generated/com/daml/ledger/api/v1/command_completion_service_grpc_pb";
 import {
     CompletionEndRequest,
@@ -31,7 +31,7 @@ export class DummyCommandCompletionServiceClient
     completionEnd(
         request: CompletionEndRequest,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: CompletionEndResponse
         ) => void
     ): ClientUnaryCall;
@@ -39,7 +39,7 @@ export class DummyCommandCompletionServiceClient
         request: CompletionEndRequest,
         metadata: Metadata,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: CompletionEndResponse
         ) => void
     ): ClientUnaryCall;
@@ -48,7 +48,7 @@ export class DummyCommandCompletionServiceClient
         metadata: Metadata,
         options: Partial<CallOptions>,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: CompletionEndResponse
         ) => void
     ): ClientUnaryCall;

--- a/test/client/DummyCommandServiceClient.ts
+++ b/test/client/DummyCommandServiceClient.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {Empty} from 'google-protobuf/google/protobuf/empty_pb';
-import {CallOptions, ClientUnaryCall, Metadata} from 'grpc';
+import {CallOptions, ClientUnaryCall, Metadata, ServiceError} from '@grpc/grpc-js';
 import {SinonSpy} from 'sinon';
 import {ICommandServiceClient} from "../../src/generated/com/daml/ledger/api/v1/command_service_grpc_pb";
 import {
@@ -29,18 +29,18 @@ export class DummyCommandServiceClient implements ICommandServiceClient {
 
     submitAndWait(
         request: SubmitAndWaitRequest,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     submitAndWait(
         request: SubmitAndWaitRequest,
         metadata: Metadata,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     submitAndWait(
         request: SubmitAndWaitRequest,
         metadata: Metadata,
         options: Partial<CallOptions>,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     submitAndWait(
         request: SubmitAndWaitRequest,
@@ -61,18 +61,18 @@ export class DummyCommandServiceClient implements ICommandServiceClient {
 
     submitAndWaitForTransaction(
         request: SubmitAndWaitRequest,
-        callback: (error: Error | null, response: SubmitAndWaitForTransactionResponse) => void
+        callback: (error: ServiceError | null, response: SubmitAndWaitForTransactionResponse) => void
     ): ClientUnaryCall;
     submitAndWaitForTransaction(
         request: SubmitAndWaitRequest,
         metadata: Metadata,
-        callback: (error: Error | null, response: SubmitAndWaitForTransactionResponse) => void
+        callback: (error: ServiceError | null, response: SubmitAndWaitForTransactionResponse) => void
     ): ClientUnaryCall;
     submitAndWaitForTransaction(
         request: SubmitAndWaitRequest,
         metadata: Metadata,
         options: Partial<CallOptions>,
-        callback: (error: Error | null, response: SubmitAndWaitForTransactionResponse) => void
+        callback: (error: ServiceError | null, response: SubmitAndWaitForTransactionResponse) => void
     ): ClientUnaryCall;
     submitAndWaitForTransaction(
         request: SubmitAndWaitRequest,
@@ -93,18 +93,18 @@ export class DummyCommandServiceClient implements ICommandServiceClient {
 
     submitAndWaitForTransactionId(
         request: SubmitAndWaitRequest,
-        callback: (error: Error | null, response: SubmitAndWaitForTransactionIdResponse) => void
+        callback: (error: ServiceError | null, response: SubmitAndWaitForTransactionIdResponse) => void
     ): ClientUnaryCall;
     submitAndWaitForTransactionId(
         request: SubmitAndWaitRequest,
         metadata: Metadata,
-        callback: (error: Error | null, response: SubmitAndWaitForTransactionIdResponse) => void
+        callback: (error: ServiceError | null, response: SubmitAndWaitForTransactionIdResponse) => void
     ): ClientUnaryCall;
     submitAndWaitForTransactionId(
         request: SubmitAndWaitRequest,
         metadata: Metadata,
         options: Partial<CallOptions>,
-        callback: (error: Error | null, response: SubmitAndWaitForTransactionIdResponse) => void
+        callback: (error: ServiceError | null, response: SubmitAndWaitForTransactionIdResponse) => void
     ): ClientUnaryCall;
     submitAndWaitForTransactionId(
         request: SubmitAndWaitRequest,
@@ -125,18 +125,18 @@ export class DummyCommandServiceClient implements ICommandServiceClient {
 
     submitAndWaitForTransactionTree(
         request: SubmitAndWaitRequest,
-        callback: (error: Error | null, response: SubmitAndWaitForTransactionTreeResponse) => void
+        callback: (error: ServiceError | null, response: SubmitAndWaitForTransactionTreeResponse) => void
     ): ClientUnaryCall;
     submitAndWaitForTransactionTree(
         request: SubmitAndWaitRequest,
         metadata: Metadata,
-        callback: (error: Error | null, response: SubmitAndWaitForTransactionTreeResponse) => void
+        callback: (error: ServiceError | null, response: SubmitAndWaitForTransactionTreeResponse) => void
     ): ClientUnaryCall;
     submitAndWaitForTransactionTree(
         request: SubmitAndWaitRequest,
         metadata: Metadata,
         options: Partial<CallOptions>,
-        callback: (error: Error | null, response: SubmitAndWaitForTransactionTreeResponse) => void
+        callback: (error: ServiceError | null, response: SubmitAndWaitForTransactionTreeResponse) => void
     ): ClientUnaryCall;
     submitAndWaitForTransactionTree(
         request: SubmitAndWaitRequest,

--- a/test/client/DummyCommandSubmissionServiceClient.ts
+++ b/test/client/DummyCommandSubmissionServiceClient.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as sinon from 'sinon';
-import {CallOptions, ClientUnaryCall, Metadata} from 'grpc';
+import {CallOptions, ClientUnaryCall, Metadata, ServiceError} from '@grpc/grpc-js';
 import {Empty} from 'google-protobuf/google/protobuf/empty_pb';
 import {ICommandSubmissionServiceClient} from "../../src/generated/com/daml/ledger/api/v1/command_submission_service_grpc_pb";
 import {SubmitRequest} from "../../src/generated/com/daml/ledger/api/v1/command_submission_service_pb";
@@ -19,18 +19,18 @@ export class DummyCommandSubmissionServiceClient
 
     submit(
         request: SubmitRequest,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     submit(
         request: SubmitRequest,
         metadata: Metadata,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     submit(
         request: SubmitRequest,
         metadata: Metadata,
         options: Partial<CallOptions>,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     submit(request: any, metadata: any, options?: any, callback?: any) {
         this.lastRequestSpy(request);

--- a/test/client/DummyLedgerConfigurationServiceClient.ts
+++ b/test/client/DummyLedgerConfigurationServiceClient.ts
@@ -3,7 +3,7 @@
 
 import * as sinon from 'sinon';
 
-import {CallOptions, ClientReadableStream, Metadata} from 'grpc';
+import {CallOptions, ClientReadableStream, Metadata} from '@grpc/grpc-js';
 import {
     GetLedgerConfigurationRequest,
     GetLedgerConfigurationResponse

--- a/test/client/DummyLedgerIdentityServiceClient.ts
+++ b/test/client/DummyLedgerIdentityServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {CallOptions, ClientUnaryCall, Metadata} from 'grpc';
+import {CallOptions, ClientUnaryCall, Metadata, ServiceError} from '@grpc/grpc-js';
 import {
     GetLedgerIdentityRequest,
     GetLedgerIdentityResponse
@@ -23,7 +23,7 @@ export class DummyLedgerIdentityServiceClient implements ILedgerIdentityServiceC
     getLedgerIdentity(
         request: GetLedgerIdentityRequest,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetLedgerIdentityResponse
         ) => void
     ): ClientUnaryCall;
@@ -31,7 +31,7 @@ export class DummyLedgerIdentityServiceClient implements ILedgerIdentityServiceC
         request: GetLedgerIdentityRequest,
         metadata: Metadata,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetLedgerIdentityResponse
         ) => void
     ): ClientUnaryCall;
@@ -40,7 +40,7 @@ export class DummyLedgerIdentityServiceClient implements ILedgerIdentityServiceC
         metadata: Metadata,
         options: Partial<CallOptions>,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetLedgerIdentityResponse
         ) => void
     ): ClientUnaryCall;

--- a/test/client/DummyPackageManagementServiceClient.ts
+++ b/test/client/DummyPackageManagementServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ClientUnaryCall, Metadata, ServiceError, CallOptions} from 'grpc';
+import {ClientUnaryCall, Metadata, ServiceError, CallOptions} from '@grpc/grpc-js';
 import {
     ListKnownPackagesRequest,
     ListKnownPackagesResponse,
@@ -14,7 +14,7 @@ import {DummyClientUnaryCall} from "../call/DummyClientUnaryCall";
 import * as sinon from "sinon";
 
 export class DummyPackageManagementServiceClient implements IPackageManagementServiceClient {
-  
+
     private readonly latestRequestSpy: sinon.SinonSpy;
     private readonly listKnownPackagesResponse: ListKnownPackagesResponse;
     private readonly uploadDarFileResponse: UploadDarFileResponse;
@@ -34,26 +34,35 @@ export class DummyPackageManagementServiceClient implements IPackageManagementSe
     }
 
     listKnownPackages(
-        request: ListKnownPackagesRequest, 
-        callback: (error: ServiceError, 
+        request: ListKnownPackagesRequest,
+        callback: (error: ServiceError,
                    response: ListKnownPackagesResponse) => void
     ): ClientUnaryCall;
 
     listKnownPackages(
-        request: ListKnownPackagesRequest, 
-        metadata: Metadata, 
+        request: ListKnownPackagesRequest,
+        metadata: Metadata,
         callback: (
-            error: ServiceError, 
+            error: ServiceError,
             response: ListKnownPackagesResponse) => void
     ): ClientUnaryCall;
 
     listKnownPackages(
-        request: ListKnownPackagesRequest, 
-        metadata: any, 
-        options?: any, 
+        request: ListKnownPackagesRequest,
+        metadata: Metadata,
+        options: Partial<CallOptions>,
+        callback: (
+            error: ServiceError,
+            response: ListKnownPackagesResponse) => void
+    ): ClientUnaryCall;
+
+    listKnownPackages(
+        request: ListKnownPackagesRequest,
+        metadata: any,
+        options?: any,
         callback?: any
     ) {
-        const cb = 
+        const cb =
             callback === undefined
                 ? options === undefined
                 ? metadata
@@ -65,30 +74,30 @@ export class DummyPackageManagementServiceClient implements IPackageManagementSe
     }
 
     uploadDarFile(
-        request: UploadDarFileRequest, 
-        callback: (error: ServiceError, 
+        request: UploadDarFileRequest,
+        callback: (error: ServiceError,
                    response: UploadDarFileResponse) => void
     ): ClientUnaryCall;
 
     uploadDarFile(
-        request: UploadDarFileRequest, 
-        metadata: Metadata, 
-        callback: (error: ServiceError, 
+        request: UploadDarFileRequest,
+        metadata: Metadata,
+        callback: (error: ServiceError,
                    response: UploadDarFileResponse) => void
     ): ClientUnaryCall;
 
     uploadDarFile(
-        request: UploadDarFileRequest, 
-        metadata: Metadata, 
-        options: Partial<CallOptions>, 
-        callback: (error: ServiceError, 
+        request: UploadDarFileRequest,
+        metadata: Metadata,
+        options: Partial<CallOptions>,
+        callback: (error: ServiceError,
                    response: UploadDarFileResponse) => void
     ): ClientUnaryCall;
 
     uploadDarFile(
-        request: any, 
-        metadata: any, 
-        options?: any, 
+        request: any,
+        metadata: any,
+        options?: any,
         callback?: any
     ) {
        this.latestRequestSpy(request);

--- a/test/client/DummyPackageServiceClient.ts
+++ b/test/client/DummyPackageServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {CallOptions, ClientUnaryCall, Metadata} from 'grpc';
+import {CallOptions, ClientUnaryCall, Metadata, ServiceError} from '@grpc/grpc-js';
 
 import * as sinon from 'sinon';
 import {IPackageServiceClient} from "../../src/generated/com/daml/ledger/api/v1/package_service_grpc_pb";
@@ -30,18 +30,18 @@ export class DummyPackageServiceClient implements IPackageServiceClient {
 
     listPackages(
         request: ListPackagesRequest,
-        callback: (error: Error | null, response: ListPackagesResponse) => void
+        callback: (error: ServiceError | null, response: ListPackagesResponse) => void
     ): ClientUnaryCall;
     listPackages(
         request: ListPackagesRequest,
         metadata: Metadata,
-        callback: (error: Error | null, response: ListPackagesResponse) => void
+        callback: (error: ServiceError | null, response: ListPackagesResponse) => void
     ): ClientUnaryCall;
     listPackages(
         request: ListPackagesRequest,
         metadata: Metadata,
         options: Partial<CallOptions>,
-        callback: (error: Error | null, response: ListPackagesResponse) => void
+        callback: (error: ServiceError | null, response: ListPackagesResponse) => void
     ): ClientUnaryCall;
     listPackages(
         request: ListPackagesRequest,
@@ -62,18 +62,18 @@ export class DummyPackageServiceClient implements IPackageServiceClient {
 
     getPackage(
         request: GetPackageRequest,
-        callback: (error: Error | null, response: GetPackageResponse) => void
+        callback: (error: ServiceError | null, response: GetPackageResponse) => void
     ): ClientUnaryCall;
     getPackage(
         request: GetPackageRequest,
         metadata: Metadata,
-        callback: (error: Error | null, response: GetPackageResponse) => void
+        callback: (error: ServiceError | null, response: GetPackageResponse) => void
     ): ClientUnaryCall;
     getPackage(
         request: GetPackageRequest,
         metadata: Metadata,
         options: Partial<CallOptions>,
-        callback: (error: Error | null, response: GetPackageResponse) => void
+        callback: (error: ServiceError | null, response: GetPackageResponse) => void
     ): ClientUnaryCall;
     getPackage(
         request: GetPackageRequest,
@@ -95,7 +95,7 @@ export class DummyPackageServiceClient implements IPackageServiceClient {
     getPackageStatus(
         request: GetPackageStatusRequest,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetPackageStatusResponse
         ) => void
     ): ClientUnaryCall;
@@ -103,7 +103,7 @@ export class DummyPackageServiceClient implements IPackageServiceClient {
         request: GetPackageStatusRequest,
         metadata: Metadata,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetPackageStatusResponse
         ) => void
     ): ClientUnaryCall;
@@ -112,7 +112,7 @@ export class DummyPackageServiceClient implements IPackageServiceClient {
         metadata: Metadata,
         options: Partial<CallOptions>,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetPackageStatusResponse
         ) => void
     ): ClientUnaryCall;

--- a/test/client/DummyPartyManagementServiceClient.ts
+++ b/test/client/DummyPartyManagementServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {ClientUnaryCall, Metadata} from 'grpc';
+import {CallOptions, ClientUnaryCall, Metadata, ServiceError} from '@grpc/grpc-js';
 import {
     AllocatePartyRequest,
     AllocatePartyResponse,
@@ -37,28 +37,37 @@ export class DummyPartyManagementServiceClient implements IPartyManagementServic
     }
 
     getParticipantId(
-        request: GetParticipantIdRequest, 
+        request: GetParticipantIdRequest,
         callback: (
-            error: Error | null, 
+            error: ServiceError | null,
             response: GetParticipantIdResponse
         ) => void
     ): ClientUnaryCall;
-    
+
     getParticipantId(
-        request: GetParticipantIdRequest, 
-        metadata: Metadata, 
+        request: GetParticipantIdRequest,
+        metadata: Metadata,
         callback: (
-            error: Error | null, 
+            error: ServiceError | null,
             response: GetParticipantIdResponse) => void
     ): ClientUnaryCall;
 
     getParticipantId(
         request: GetParticipantIdRequest,
-        metadata: any, 
-        options?: any, 
+        metadata: Metadata,
+        options: Partial<CallOptions>,
+        callback: (
+            error: ServiceError | null,
+            response: GetParticipantIdResponse) => void
+    ): ClientUnaryCall;
+
+    getParticipantId(
+        request: GetParticipantIdRequest,
+        metadata: any,
+        options?: any,
         callback?: any
     ){
-        const cb = 
+        const cb =
             callback === undefined
                ? options === undefined
                ? metadata
@@ -72,7 +81,7 @@ export class DummyPartyManagementServiceClient implements IPartyManagementServic
     getParties(
         request: GetPartiesRequest,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetPartiesResponse
         ) => void
     ): ClientUnaryCall;
@@ -81,7 +90,16 @@ export class DummyPartyManagementServiceClient implements IPartyManagementServic
         request: GetPartiesRequest,
         metadata: Metadata,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
+            response: GetPartiesResponse) => void
+    ): ClientUnaryCall;
+
+    getParties(
+        request: GetPartiesRequest,
+        metadata: Metadata,
+        options: Partial<CallOptions>,
+        callback: (
+            error: ServiceError | null,
             response: GetPartiesResponse) => void
     ): ClientUnaryCall;
 
@@ -101,27 +119,36 @@ export class DummyPartyManagementServiceClient implements IPartyManagementServic
         cb(null, this.getPartiesResponse);
         return DummyClientUnaryCall.Instance;
     };
-    
+
     listKnownParties(
-        request: ListKnownPartiesRequest, 
+        request: ListKnownPartiesRequest,
         callback: (
-            error: Error | null, 
+            error: ServiceError | null,
             response: ListKnownPartiesResponse
         ) => void
     ): ClientUnaryCall;
 
     listKnownParties(
-        request: ListKnownPartiesRequest, 
-        metadata: Metadata, 
+        request: ListKnownPartiesRequest,
+        metadata: Metadata,
         callback: (
-            error: Error | null, 
+            error: ServiceError | null,
             response: ListKnownPartiesResponse) => void
     ): ClientUnaryCall;
 
     listKnownParties(
-        request: ListKnownPartiesRequest, 
-        metadata: any, 
-        options?: any, 
+        request: ListKnownPartiesRequest,
+        metadata: Metadata,
+        options: Partial<CallOptions>,
+        callback: (
+            error: ServiceError | null,
+            response: ListKnownPartiesResponse) => void
+    ): ClientUnaryCall;
+
+    listKnownParties(
+        request: ListKnownPartiesRequest,
+        metadata: any,
+        options?: any,
         callback?: any
     ) {
         const cb =
@@ -136,24 +163,33 @@ export class DummyPartyManagementServiceClient implements IPartyManagementServic
     };
 
     allocateParty(
-        request: AllocatePartyRequest, 
-        callback: (error: Error | null, 
+        request: AllocatePartyRequest,
+        callback: (error: ServiceError | null,
             response: AllocatePartyResponse
         ) => void
     ): ClientUnaryCall;
-    
+
     allocateParty(
-        request: AllocatePartyRequest, 
-        metadata: Metadata, 
+        request: AllocatePartyRequest,
+        metadata: Metadata,
         callback: (
-            error: Error | null, 
+            error: ServiceError | null,
             response: AllocatePartyResponse) => void
     ): ClientUnaryCall;
 
     allocateParty(
-        request: AllocatePartyRequest, 
-        metadata: any, 
-        options?: any, 
+        request: AllocatePartyRequest,
+        metadata: Metadata,
+        options: Partial<CallOptions>,
+        callback: (
+            error: ServiceError | null,
+            response: AllocatePartyResponse) => void
+    ): ClientUnaryCall;
+
+    allocateParty(
+        request: AllocatePartyRequest,
+        metadata: any,
+        options?: any,
         callback?: any
     ){
         const cb =

--- a/test/client/DummyResetServiceClient.ts
+++ b/test/client/DummyResetServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {CallOptions, ClientUnaryCall, Metadata} from 'grpc';
+import {CallOptions, ClientUnaryCall, Metadata, ServiceError} from '@grpc/grpc-js';
 
 import * as sinon from 'sinon';
 
@@ -21,18 +21,18 @@ export class DummyResetServiceClient implements IResetServiceClient {
 
     reset(
         request: ResetRequest,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     reset(
         request: ResetRequest,
         metadata: Metadata,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     reset(
         request: ResetRequest,
         metadata: Metadata,
         options: Partial<CallOptions>,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     reset(
         request: ResetRequest,

--- a/test/client/DummyTimeServiceClient.ts
+++ b/test/client/DummyTimeServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {CallOptions, ClientReadableStream, ClientUnaryCall, Metadata} from 'grpc';
+import {CallOptions, ClientReadableStream, ClientUnaryCall, Metadata, ServiceError} from '@grpc/grpc-js';
 
 import * as sinon from 'sinon';
 import {Empty} from 'google-protobuf/google/protobuf/empty_pb';
@@ -44,18 +44,18 @@ export class DummyTimeServiceClient implements ITimeServiceClient {
 
     setTime(
         request: SetTimeRequest,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     setTime(
         request: SetTimeRequest,
         metadata: Metadata,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     setTime(
         request: SetTimeRequest,
         metadata: Metadata,
         options: Partial<CallOptions>,
-        callback: (error: Error | null, response: Empty) => void
+        callback: (error: ServiceError | null, response: Empty) => void
     ): ClientUnaryCall;
     setTime(
         request: SetTimeRequest,

--- a/test/client/DummyTransactionServiceClient.ts
+++ b/test/client/DummyTransactionServiceClient.ts
@@ -3,7 +3,7 @@
 
 import * as sinon from 'sinon';
 
-import {CallOptions, ClientReadableStream, ClientUnaryCall, Metadata} from 'grpc';
+import {CallOptions, ClientReadableStream, ClientUnaryCall, Metadata, ServiceError} from '@grpc/grpc-js';
 import {Timestamp} from 'google-protobuf/google/protobuf/timestamp_pb';
 import {ITransactionServiceClient} from "../../src/generated/com/daml/ledger/api/v1/transaction_service_grpc_pb";
 import {
@@ -74,7 +74,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
     getTransactionByEventId(
         request: GetTransactionByEventIdRequest,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -83,7 +83,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
         request: GetTransactionByEventIdRequest,
         metadata: Metadata,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -93,7 +93,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
         metadata: Metadata,
         options: Partial<CallOptions>,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -118,7 +118,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
     getFlatTransactionByEventId(
         request: GetTransactionByEventIdRequest,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetFlatTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -127,7 +127,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
         request: GetTransactionByEventIdRequest,
         metadata: Metadata,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetFlatTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -137,7 +137,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
         metadata: Metadata,
         options: Partial<CallOptions>,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetFlatTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -162,7 +162,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
     getFlatTransactionById(
         request: GetTransactionByIdRequest,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetFlatTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -171,7 +171,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
         request: GetTransactionByIdRequest,
         metadata: Metadata,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetFlatTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -181,7 +181,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
         metadata: Metadata,
         options: Partial<CallOptions>,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetFlatTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -206,7 +206,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
     getTransactionById(
         request: GetTransactionByIdRequest,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -215,7 +215,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
         request: GetTransactionByIdRequest,
         metadata: Metadata,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -225,7 +225,7 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
         metadata: Metadata,
         options: Partial<CallOptions>,
         callback: (
-            error: Error | null,
+            error: ServiceError | null,
             response: GetTransactionResponse
         ) => void
     ): ClientUnaryCall;
@@ -249,20 +249,20 @@ export class DummyTransactionServiceClient implements ITransactionServiceClient 
 
     getLedgerEnd(
         request: GetLedgerEndRequest,
-        callback: (error: Error | null, response: GetLedgerEndResponse) => void
+        callback: (error: ServiceError | null, response: GetLedgerEndResponse) => void
     ): ClientUnaryCall;
 
     getLedgerEnd(
         request: GetLedgerEndRequest,
         metadata: Metadata,
-        callback: (error: Error | null, response: GetLedgerEndResponse) => void
+        callback: (error: ServiceError | null, response: GetLedgerEndResponse) => void
     ): ClientUnaryCall;
 
     getLedgerEnd(
         request: GetLedgerEndRequest,
         metadata: Metadata,
         options: Partial<CallOptions>,
-        callback: (error: Error | null, response: GetLedgerEndResponse) => void
+        callback: (error: ServiceError | null, response: GetLedgerEndResponse) => void
     ): ClientUnaryCall;
 
     getLedgerEnd(

--- a/test/client/LedgerClient.spec.ts
+++ b/test/client/LedgerClient.spec.ts
@@ -3,7 +3,7 @@
 
 import {assert, expect} from 'chai';
 import * as sinon from 'sinon';
-import {ServerCredentials} from 'grpc';
+import {ServerCredentials} from '@grpc/grpc-js';
 import {DamlLedgerClient} from "../../src";
 import {DummyServer} from "./DummyServer";
 
@@ -13,7 +13,7 @@ describe("DamlLedgerClient", () => {
 
     const spy = sinon.spy();
     const server = new DummyServer(ledgerId, spy);
-    const port = server.bind('0.0.0.0:0', ServerCredentials.createInsecure());
+    let port: any = undefined;
 
     const emptyCommands = {
         commands: {
@@ -24,8 +24,15 @@ describe("DamlLedgerClient", () => {
         }
     };
 
-    before(() => {
-        server.start();
+    before((done) => {
+        server.bindAsync('0.0.0.0:0', ServerCredentials.createInsecure(), (err, actualPort) => {
+            if (err) {
+                return done(err);
+            }
+            port = actualPort;
+            server.start();
+            done();
+        });
     });
 
     after(() => {

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": [ "es2015" ],
+    "target": "es6",
+    "module": "commonjs",
     "incremental": true,
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
The former is deprecated and will stop receiving updates early 2021.

This does work but there are a few issues:
1. This does require ES6. The reason for this is that `grpc-js` is required in ES6 and if we don’t target ES6 in TypeScript every call to `new` will fail at runtime. I don’t think this is a huge issue. ES6 is pretty old and we can double check that the main users of this library support this.
2. The typescript typings are pretty weird despite claiming to support grpc-js. They provide typings for identifiers that don’t exist and will just throw `undefined` at runtime, they require all kinds of casting that seems like it definitely should not be necessary, ….  Looking through the issue tracker of https://github.com/agreatfool/grpc_tools_node_protoc_ts this all seems to be expected (this is literally what the examples do) so I don’t think I’ve messed anything up here. There is a PR to introduce a typescript codegen directly into `grpc-node` https://github.com/grpc/grpc-node/pull/1474. Hopefully that will be a bit better but it still seems to require quite a bit of casting, require runtime loading of the proto files, … so it’s not clear to me that it’s that much better.

What does give me some confidence here is that all the weirdness is limited to internal implementation details and tests. There is literally no change to `IntegrationTests.spec.ts`. I’ll check `ex-tutorial-nodejs` as well.